### PR TITLE
Key replacement as alias

### DIFF
--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -454,13 +454,13 @@ def display_menu():
             initialize_tap_groups()
         elif choice == '4': 
             try:
-                new_group = input("Enter new key pair (2 keys separated by a comma): ").replace(" ", "").split(',')
-                if len(new_group) == 2:
+                new_group = input("Enter keys seperated by comma (2 keys = replacement, 3+ = alias): ").replace(" ", "").split(',')
+                if len(new_group) >= 2:
                     add_group(new_group, key_replacement_groups)
                     initialize_key_replacement_groups()
                     save_groups(FILE_NAME_KEY_REPLACEMENTS, key_replacement_groups)
                 else:
-                    text = "Error: For a pair only sets of 2 keys are valid."
+                    text = "Error: at least 2 keys are needed."
                     invalid_input = True
             except KeyError as error_msg:
                 text = f"Error: Wrong string as a key used: {error_msg}"

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -266,6 +266,10 @@ def win32_event_filter(msg, data):
                         # key combination marked with + between keys: e.g. shift_left+u -> shift down, u down, u up, shift up
                         # key up and down marked by + and - before keys: e.g. -shift_left, n, e, w, +shift_left --> NEW
                             # have to change reverse keys for it to work with -, but is similar in function
+                        # maybe it is possible to also use + and - as modifier for the input_key,
+                            # to differentiate between key press and key release as trigger
+                            # 2 alias on one key usable then - one on press, one on release xD
+
                         # readme and description need a bigger update xD
 
                         listener.suppress_event()

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -263,15 +263,25 @@ def win32_event_filter(msg, data):
                             controller.release(key_code)
                             sleep(randint(ALIAS_MIN_DELAY_IN_MS, ALIAS_MAX_DELAY_IN_MS) / 1000)
 
+                        '''
                         # key combination marked with + between keys: e.g. shift_left+u -> shift down, u down, u up, shift up
                         # key up and down marked by + and - before keys: e.g. -shift_left, n, e, w, +shift_left --> NEW
                             # have to change reverse keys for it to work with -, but is similar in function
                         # maybe it is possible to also use + and - as modifier for the input_key,
                             # to differentiate between key press and key release as trigger
                             # 2 alias on one key usable then - one on press, one on release xD
+                        # though to the end: key groups will look like
+                        -k,-shift,h,e,l,l,o,+shift          # k down -> HELLO
+                        +k,-shift,w,o,r,l,d,+shift          # k up   -> WORLD
+                        -l,-l,mouse_right                   # l down -> l down, right mouse click
+                        h, u   # equivalent to h-,u-;h+,u+  # h will be replaced by u: h down -> u down, h up -> u up
+                            # maybe really just define h-,u-;h+,u+ and split at ; (has to be compatible with shared typ_groups )
+
+                        # include delay for a key to change the delay after that key:
+                        -h,-shift,h/10,e/5,l,l,o,+shift     # custom delay of 10 ms after h and 5 ms after e
 
                         # readme and description need a bigger update xD
-
+                        '''
                         listener.suppress_event()
 
         # Stop the listener if the END key is released

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -255,12 +255,18 @@ def win32_event_filter(msg, data):
 
                     elif is_keydown: # so up key will be ignored
                         for key in group[1:]:
-                            print(f"alias press: {key}")
+                            if DEBUG: print(f"alias press: {key}")
                             key_code = keyboard.KeyCode.from_vk(key)
                             controller.press(key_code)
                             sleep(ALIAS_DELAY / 1000)
                             controller.release(key_code)
                             sleep(ALIAS_DELAY / 1000)
+
+                        # key combination marked with + between keys: e.g. shift_left+u -> shift down, u down, u up, shift up
+                        # key up and down marked by + and - before keys: e.g. -shift_left, n, e, w, +shift_left --> NEW
+                            # have to change reverse keys for it to work with -, but is similar in function
+                        # readme and description need a bigger update xD
+
                         listener.suppress_event()
 
         # Stop the listener if the END key is released

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -16,13 +16,14 @@ PRINT_VK_CODES = False
 
 # AntiCheat testing (ACT)
 ACT_DELAY = False
-ACT_MIN_DELAY_IN_MS = 0
+ACT_MIN_DELAY_IN_MS = 2
 ACT_MAX_DELAY_IN_MS = 10
 ACT_CROSSOVER = False # will also force delay
 ACT_CROSSOVER_PROPABILITY_IN_PERCENT = 50
 
 # Alias delay between presses and releases
-ALIAS_DELAY = 10 # 10 ms
+ALIAS_MIN_DELAY_IN_MS = 2 
+ALIAS_MAX_DELAY_IN_MS = 10
 
 # Define File name for saving of Tap Groupings and Key Groups
 FILE_NAME_TAP_GROUPS = 'tap_groups.txt'
@@ -258,9 +259,9 @@ def win32_event_filter(msg, data):
                             if DEBUG: print(f"alias press: {key}")
                             key_code = keyboard.KeyCode.from_vk(key)
                             controller.press(key_code)
-                            sleep(ALIAS_DELAY / 1000)
+                            sleep(randint(ALIAS_MIN_DELAY_IN_MS, ALIAS_MAX_DELAY_IN_MS) / 1000)
                             controller.release(key_code)
-                            sleep(ALIAS_DELAY / 1000)
+                            sleep(randint(ALIAS_MIN_DELAY_IN_MS, ALIAS_MAX_DELAY_IN_MS) / 1000)
 
                         # key combination marked with + between keys: e.g. shift_left+u -> shift down, u down, u up, shift up
                         # key up and down marked by + and - before keys: e.g. -shift_left, n, e, w, +shift_left --> NEW

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -183,10 +183,10 @@ def initialize_key_groups():
     for group_index, group in enumerate(key_groups):
         for key in group:
 
-            #TODO: firstbreak up the combination into a list of keys
+            #TODO: first break up the combination into a list of keys
 
 
-            #TODO: then seperate delay info from string
+            #seperate delay info from string
             if '|' in key:
                 key, *delays = key.split('|')
                 print(f"delays for {key}: {delays}")
@@ -366,40 +366,47 @@ def win32_event_filter(msg, data):
                             listener.suppress_event()   
 
                         '''
-                        # key combination marked with + between keys: e.g. shift_left+u -> shift down, u down, u up, shift up
-                        # key up and down marked by + and - before keys: e.g. -shift_left, n, e, w, +shift_left --> NEW
-                            # have to change reverse keys for it to work with -, but is similar in function
-                        # maybe it is possible to also use + and - as modifier for the input_key,
-                            # to differentiate between key press and key release as trigger
-                            # 2 alias on one key usable then - one on press, one on release xD
-                        # though to the end: key groups will look like
-                        -k,-shift,h,e,l,l,o,+shift          # k down -> HELLO
-                        +k,-shift,w,o,r,l,d,+shift          # k up   -> WORLD
-                        -l,-l,mouse_right                   # l down -> l down, right mouse click
-                        h, u   # equivalent to h-,u-;h+,u+  # h will be replaced by u: h down -> u down, h up -> u up
-                            # maybe really just define h-,u-;h+,u+ and split at ; (has to be compatible with shared typ_groups )
+                        [o] # key combination marked with + between keys: e.g. shift_left+u -> shift down, u down, u up, shift up
+                            [x] somewhat solved by using -shift,key,+shift - even more flexible
+                        [x] # key up and down marked by + and - before keys: e.g. -shift_left, n, e, w, +shift_left --> NEW
+                            [x] # have to change reverse keys for it to work with -, but is similar in function
+                        [x] maybe it is possible to also use + and - as modifier for the input_key,
+                            [x] # to differentiate between key press and key release as trigger
+                            [x] # 2 alias on one key usable then - one on press, one on release xD
+                        [x] # though to the end: key groups will look like
+                            -k,-shift,h,e,l,l,o,+shift          # k down -> HELLO
+                            +k,-shift,w,o,r,l,d,+shift          # k up   -> WORLD
+                            -l,-l,mouse_right                   # l down -> l down, right mouse click
+                            h, u   # equivalent to h-,u-;h+,u+  # h will be replaced by u: h down -> u down, h up -> u up
+                                # maybe really just define h-,u-;h+,u+ and split at ; (has to be compatible with shared typ_groups )
 
-                        # include delay for a key to change the delay after that key:
-                        -h,-shift,h/10,e/5,l,l,o,+shift     # custom delay of 10 ms after h and 5 ms after e
+                        [x] # include delay for a key to change the delay after that key:
+                                -h,-shift,h/10,e/5,l,l,o,+shift     # custom delay of 10 ms after h and 5 ms after e
                         
-                        # global state list with 262 (0-261) elements for each key representing pressed or not
-                        # global list with lists of all combinations to be tracked
-                            # fast check by just asking if the indize of state_list[key of combination] is pressed
-                        # global state of last_key_pressed
-                        # omb_last_key_pressed for each combination
-                            # e.g. tapgroup a,d
-                            a pressed -> last_key_pressed = a
-                                state[a] = 1, looked up if in combination; set comb_last_key_pressed = a; a press send
-                            d pressed -> last_key_pressed = d
-                                state[d] = 1 and d press send
-                                key combination triggered
-                                    comb_last_key_pressed released
-                            d released
-                                state[d] = 0 and d release send
-                                check combination for num of sum greater 1
-                                    send comb_last_key_pressed
-                                    ### but this is d which was released
-
+                        # problem is that key combination can not be recognised as an input
+                            # global state list with 262 (0-261) elements for each key representing pressed or not
+                            # global list with lists of all combinations to be tracked
+                                # fast check by just asking if the indize of state_list[key of combination] is pressed
+                            # global state of last_key_pressed
+                            # comb_last_key_pressed for each combination
+                                # e.g. tapgroup a,d
+                                a pressed -> last_key_pressed = a
+                                    state[a] = 1, looked up if in combination; set comb_last_key_pressed = a; a press send
+                                d pressed -> last_key_pressed = d
+                                    state[d] = 1 and d press send
+                                    key combination triggered
+                                        comb_last_key_pressed released
+                                d released
+                                    state[d] = 0 and d release send
+                                    check combination for num of sum greater 1
+                                        send comb_last_key_pressed
+                                        ### but this is d which was released
+                        
+                        # linux compatibility:
+                            # replace win32_event_filter with generic on_press and on_release calls 
+                            # supress=True to supress everything
+                            # pipe through the script every input
+                            # logic for not sendung key when used in key groups as trigger
 
                         # readme and description need a bigger update xD
 
@@ -462,7 +469,6 @@ def win32_event_filter(msg, data):
             else:
                 key_code = keyboard.KeyCode.from_vk(vk_code)
 
-            # TODO: is this even working as intented?
             if is_keydown: # and not output_is_reversed:
                 controller_dict[is_mouse_key].press(key_code)
             else:

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -95,7 +95,9 @@ vk_codes_dict = {
     'exsel': 248, 'erase_eof': 249, 'play': 250, 'zoom': 251,
     'pa1': 253, 'oem_clear': 254,
     # some vk_codes for german keyboard layout
-    '<': 226, 'ä' : 222, 'ö' : 192, 'ü': 186, '´': 221, 'copilot': 134, 
+    '<': 226, 'ä': 222, 'ö': 192, 'ü': 186, '´': 221, 'copilot': 134, 
+    # s
+    '-': 189, '+': 187, '#': 191, ',': 188, '.':190,
 }
 
 def load_groups(file_name, data_object):

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -346,23 +346,30 @@ def win32_event_filter(msg, data):
 
                         if should_fire_alias:
                             for i, code in enumerate(vk_codes):
-                                key_code = keyboard.KeyCode.from_vk(code)
+
+                                is_mouse_key = code in mouse_vk_codes
+                                if is_mouse_key:
+                                    key_code = mouse_vk_codes_dict[code]
+                                else:
+                                    key_code = keyboard.KeyCode.from_vk(code)
+
+                                #key_code = keyboard.KeyCode.from_vk(code)
                                 key_delays = key_groups_key_delays[group_index][i]
 
                                 if DEBUG: print(i, code)
 
                                 if new_key_press_modifiers[i] == None:
-                                    controller.press(key_code)
+                                    controller_dict[is_mouse_key].press(key_code)
                                     delay(*key_delays)
-                                    controller.release(key_code) 
+                                    controller_dict[is_mouse_key].release(key_code) 
                                 elif new_key_press_modifiers[i] == 'up':
-                                    controller.release(key_code)
+                                    controller_dict[is_mouse_key].release(key_code)
                                 elif new_key_press_modifiers[i] == 'down':
-                                    controller.press(key_code)
+                                    controller_dict[is_mouse_key].press(key_code)
                                 elif new_key_press_modifiers[i] == 'reversed': 
-                                    controller.release(key_code)
+                                    controller_dict[is_mouse_key].release(key_code)
                                     delay(*key_delays)
-                                    controller.press(key_code)
+                                    controller_dict[is_mouse_key].press(key_code)
                                 delay(*key_delays)
 
                             listener.suppress_event()   


### PR DESCRIPTION
NEW: Added support for Aliases in Key Groups (genamed that file also)

You can now put things like this into the key groups file (directly via menu or just edit the key_groups.txt):

- `-k,  p|10,  o|5,  i|15|3`   
  - when k is pressed , send p with a max delay of 10, then o with may delay of 5, then i with min delay of 3 and max of 10 (order of delays is free - it fetches the smaller one as min and the bigger one as max.
- `+o,r,e,v,e,r,s,e,d,-left_shift,w,o,r,l,d,+left_shift`    
  - when o is released writes "reversedWORLD"
- `-o,-left_shift,h,e,l,l,o,+left_shift,w,o,r,l,d`        
  - when o is pressed writes "HELLOWORLD"
- `--,-+,++`
  - when minus is pressed sends a + press and release
- `+-,o,k`
  - when minus is released writes "ok"

some explanation:
- `` nothing in front of a key is a press and release (normal)
- `-` in front of a key is a press (down)
- `+` in front of a key is a release (up)
- `#` in front of a key is a release and a key (reversed input)
- `|` behind a key is the the max delay for this single key (e.g. `-k|10` -> press k with a max delay of 10)
- `|*max*|*min*` defines min and max delay (e.g. `-k|10|2` or `-k|2|10` -> press k with a max delay of 10 and min delay of 2)

This is only usable in key groups. not supported in tap_groups yet.

See #21 for further info

Update of ReadMe will come later. :-D

pls give feedback in the discussion - would like to see for what you use this functionality :-D