### PR TITLE
Update free_snap_tap.py

### DIFF
--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -328,7 +328,7 @@ def win32_event_filter(msg, data):
     is_simulated = is_simulated_key_event(data.flags)
 
     if (PRINT_VK_CODES and is_keydown) or DEBUG:
-        print(f"time: {data.time}, vk_code: {vk_code} - {"press  " if is_keydown else "release"} - {"simulated" if is_simulated else "real"}")
+        print(f"time: {data.time}, vk_code: {vk_code} - {'press' if is_keydown else 'release'} - {'simulated' if is_simulated else 'real'}")
 
     # if DEBUG: 
 


### PR DESCRIPTION
Updated the Line because in python v3.11.6 I got the following error. 
 line 331
    print(f"time: {data.time}, vk_code: {vk_code} - {"press  " if is_keydown else "release"} - {"simulated" if is_simulated else "real"}")
                                                      ^^^^^
SyntaxError: f-string: expecting '}'

However in python3.12 I did not get it, so only had this issue with this python version...
With the updated version it works in every version.