### PR TITLE
Bugfixes + Qol improvements to 0.9.3 + extension of formula evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,6 @@
 /testing
 /pictures
 /__pycache__
-free_snap_tap.exe -nomenu start.bat
 free_snap_tap.spec
-free_snap_tap.py -debug.bat
-my_taps.txt
-my_keys.txt
+test_batch.bat
 free_snap_tap.exe
-notes.md

--- a/FSTconfig.txt
+++ b/FSTconfig.txt
@@ -3,5 +3,24 @@ a,d
 w,s
 
 # Rebinds
+n:j
+o:p
+-u:+u
++u:-u
+z:!z
+#left_shift: ^left_shift
+c:left_control
+v:suppress
+
 
 # Macros
+#-k,-l: -left_shift,h|100|100,e|100|100,l|(t("+w")+1000),l|100|100,o|100|100,+left_shift
+k:h,-i|(t("+w")+1000),+i,h,o
+#r, !left_shift: ^right_mouse
+
++w|(tr("+w")>100), !s, !ctrl, !space  :  +w|15|5, -s|(cs("+w")), +s|0|0
++s|(tr("+s")>100), !w, !ctrl, !space  :  +s|15|5, -w|(cs("+s")), +w|0|0
++a|(tr("+a")>100), !d, !ctrl, !space  :  +a|15|5, -d|(cs("+a")), +d|0|0
++d|(tr("+d")>100), !a, !ctrl, !space  :  +d|15|5, -a|(cs("+d")), +a|0|0
+
++space|(150<tr("+space")<500), !ctrl : +space, -ctrl|(550-tr("+space")), +ctrl|0|0

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ v : suppress
 # automatic application of healing syringe and switch back to last weapon
 # (125<tr("+x")<900): will not be triggered if tapped really quickly or hold over 900 ms
 # the longest it will be waiting to release x is 900ms after x was pressed (900-tr("+x")) to make sure it is equipped fully
-+x|(125<tr("+x")<900) : +x|(900-tr("+x")), -left_mouse|600|600, +left_mouse|0|0, q
++x|(125<tr("+x")<800) : +x|(1000-tr("+x")), -left_mouse|700|700, +left_mouse|0|0, q
 ```
 
 - Dynamic evaluation is instead used of set delays behind the `|` of a key. e.g. `+w|(tr("+w")>100)`
@@ -208,6 +208,32 @@ pause
 ```
 
 ## Current Version Information
+
+**V0.9.4**
+
+- NEW:
+  - formula evaluation now extended to rebind trigger
+    - `c|(p("0")) : ctrl` - only rebind c to ctrl if 0 is pressed
+      - in combination with toggle function `0 : ^0` the 0 key can be toggled and the rebinds for a set of keys then change with just one key press or while just holding the key. (that is a functionality I always wanted to have in MMOs :-) - rebind everthing with a button press)
+  - 2 new evaluation functions to be usable
+    - `p("key")` - checks if the key is **P**ressed (current real key press)
+    - `r("key")` - checks if the key is **R**eleased - literally `not p()`
+  - multiple formula can now be added to any key and will be evaluated
+    - `+w|(not p("s"))|(tr("+w")>100)` - only trigger on +w if +s is not pressed and w was pressed for at least 100 ms
+  - False/True Evaluation now also usable in played keys of macro
+    - `+s|(not p("s"))|100|100` - only release s if s is not pressed (current real key press) and if played will delay for 100 ms (100ms max and 100 ms min)
+      - delays can still be added as numbers but only the first 2 will be used for min and max random delay
+    - `-s|(r("w"))|(cs("+w"))` - only press s if w is released (current real key state) and then use custom delay defined by the function cs("+w")
+
+- Bugfixes:
+  - Macros triggered with every key event when trigger was fulfilled even if key event was not part of the trigger - bug introduced in V0.9.3 by fixing non evaluation of formula if there was only one key in trigger group
+  - If time of a key in a formula was not pressed before could lead to an undefined state - will now return 0/False if no valid value for time pressed or time released exist yet
+
+- QOL:
+  - removed '"unknown start argument: ", arg' outputs if start arguments were commented out in batch file. Now ':' or '#' will be seen as commenting out and the argument that is still received will not be printed out any more
+  - toggle modifier '^' was not shown in display of rebinds
+  - toggle state will now be overwritten by actual manual input of the same key - behavior is now no longer independent of real key press/release state as before
+  - toggle states will be reseted and toggled keys released if manual paused or focusapp paused
 
 **V0.9.3**
 - See: #### New with 9.3: dynamic evaluation of delays - programmable delays dependent on key press and release times

--- a/tap_keyboard.py
+++ b/tap_keyboard.py
@@ -215,6 +215,8 @@ class Key_Event(object):
     def _get_sign(self):
         if self._prohibited:
             return '!'
+        elif self._toggle:
+            return '^'
         else:
             return '-' if self._is_press else '+'
     
@@ -228,17 +230,16 @@ class Key_Event(object):
     #         return f"Key_Event({self._key_string}, {self._is_press}, {self._delays})"
         
     def __repr__(self):
-        delay = f"|{self._delays[0]}|{self._delays[1]}"#
         delay = ''
         if self._key_string is None:
             return f"{self._get_sign()}{self._vk_code}{delay}"
         else:
-            return f"{self._get_sign()}{self._vk_code}{delay}"
+            return f"{self._get_sign()}{self._key_string}{delay}"
             # return f"{self._get_sign()}{self._key_string}{delay}"
    
 class Key(object):
     
-    def __init__(self, key_string, vk_code, reversed = False, delays=[0,0]) -> None:
+    def __init__(self, vk_code, key_string='', reversed = False, delays=[0,0]) -> None:
         self._key_string = key_string
         self._delays = delays
         self._reversed = reversed


### PR DESCRIPTION
**V0.9.4**

- NEW:
  - formula evaluation now extended to rebind trigger
    - `c|(p("0")) : ctrl` - only rebind c to ctrl if 0 is pressed
      - in combination with toggle function `0 : ^0` the 0 key can be toggled and the rebinds for a set of keys then change with just one key press or while just holding the key. (that is a functionality I always wanted to have in MMOs :-) - rebind everthing with a button press)
  - 2 new evaluation functions to be usable
    - `p("key")` - checks if the key is **P**ressed (current real key press)
    - `r("key")` - checks if the key is **R**eleased - literally `not p()`
  - multiple formula can now be added to any key and will be evaluated
    - `+w|(not p("s"))|(tr("+w")>100)` - only trigger on +w if +s is not pressed and w was pressed for at least 100 ms
  - False/True Evaluation now also usable in played keys of macro
    - `+s|(not p("s"))|100|100` - only release s if s is not pressed (current real key press) and if played will delay for 100 ms (100ms max and 100 ms min)
      - delays can still be added as numbers but only the first 2 will be used for min and max random delay
    - `-s|(r("w"))|(cs("+w"))` - only press s if w is released (current real key state) and then use custom delay defined by the function cs("+w")

- Bugfixes:
  - Macros triggered with every key event when trigger was fulfilled even if key event was not part of the trigger - bug introduced in V0.9.3 by fixing non evaluation of formula if there was only one key in trigger group
  - If time of a key in a formula was not pressed before could lead to an undefined state - will now return 0/False if no valid value for time pressed or time released exist yet

- QOL:
  - removed '"unknown start argument: ", arg' outputs if start arguments were commented out in batch file. Now ':' or '#' will be seen as commenting out and the argument that is still received will not be printed out any more
  - toggle modifier '^' was not shown in display of rebinds
  - toggle state will now be overwritten by actual manual input of the same key - behavior is now no longer independent of real key press/release state as before
  - toggle states will be reseted and toggled keys released if manual paused or focusapp paused