### PR TITLE
V1.1.1 Alias Repeat

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -93,15 +93,29 @@
 - reset press state before releasing all keys to prevent suppression because of contradiction a real key state
 
 - repeat on ke basis?
-  - toggle_repeat|<alias>
+  - ke vk_code as differentiation 
+  - changed behavior of Repeat_thread - would then get a key_group based on the alias that is needs to play
+    - how to define the interval? interval from start or delay after last part is executed?
+  - toggle_repeat|<alias>4000
   - start_repeat|<alias>
   - stop_repeat|<alias>
   - reset_repeat|<alias>
 
-  - ke|toggle_repeat('<alias>') 
+  - reset|(name) as general reset statement instead of reset ke
+    - removal of reset_0-reset_30
+    - removal of code for reset by resetcode
+  - reset_all
+  
+
+could be equivalent to:
+
+  - ke|(toggle_repeat('<alias>4000'))
   - ke|start_repeat('<alias>') 
   - ke|stop_repeat('<alias>') 
   - ke|reset_repeat('<alias>') 
+
+- Do I need the ability to use commas in evaluations for that?
+  - would have to look for '(' and ')' and ignore commas in it
 
 ### todo
 

--- a/change_log.md
+++ b/change_log.md
@@ -82,9 +82,26 @@
 ???:
 -should every invocation or reset as invocation result in True?
   - can always be stopped from sending by following up with a False eval .. e.g. |(False)
-  - start_repeat, toggle_repeat eval to False, because a Repeat thread takes constraints[1:] with into the repeat ...
-    - so v|(start_repeat)|(False) would try to repeat v|(False) and never send anything
-  - and stop_repeat eval to False - because is needs to be used with the same ke to be stopped and when you want to stop something you do not want to execute it first again...
+  - (start_repeat()), (toggle_repeat()) MUST eval to False, because a Repeat_thread takes constraints[1:] with it into the repeat ...
+    - so v|(start_repeat)|(False) would try to repeat v|(False) and never send anything - learning by trial xD
+  - and (stop_repeat()) eval to False - because is needs to be used with the same ke to be stopped and when you want to stop something you do not want to execute it first again ...
+
+### Idea and TODO:
+- lots of doc_string missing
+- use aliases for repeat input: e.g. ke|toggle_repeat('<repeat_scan>') 
+  - would be no longer dependent on actual ke and way more flexible and easy to use
+- reset press state before releasing all keys to prevent suppression because of contradiction a real key state
+
+- repeat on ke basis?
+  - toggle_repeat|<alias>
+  - start_repeat|<alias>
+  - stop_repeat|<alias>
+  - reset_repeat|<alias>
+
+  - ke|toggle_repeat('<alias>') 
+  - ke|start_repeat('<alias>') 
+  - ke|stop_repeat('<alias>') 
+  - ke|reset_repeat('<alias>') 
 
 ### todo
 

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -87,7 +87,7 @@ class Status_Indicator():
         self.context_menu.add_separator()
         self.context_menu.add_command(label="Close Indicator", command=self.close_window)
         self.context_menu.add_command(label="Toggle Crosshair", command=self.toggle_crosshair)
-        self.context_menu.add_command(label="Display internal state", command=self._fst.display_internal_repr_groups)
+        #self.context_menu.add_command(label="Display internal state", command=self._fst.display_internal_repr_groups)
         
         # Bind right-click to show the context menu
         self.canvas.bind("<Button-3>", self.show_context_menu)

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -69,6 +69,7 @@ class FST_Keyboard():
         self._macros = []
         self._macros_alias_dict = {}
         self._macro_sequence_alias_list = []
+        self._key_group_by_alias = {}
         
         self._mouse_listener = None
         self._listener = None
@@ -114,6 +115,9 @@ class FST_Keyboard():
     @property
     def macro_sequence_alias_list(self):
         return self._macro_sequence_alias_list
+    @property
+    def key_group_by_alias(self):
+        return self._key_group_by_alias
     
     def convert_to_vk_code(self, key):
         '''
@@ -149,23 +153,23 @@ class FST_Keyboard():
         # only for display purposes
         self._rebinds = []
         self._macros = []
-        
+                
         def extract_data_from_key(key_string):           
             #separate delay info from string
             if '|' in key_string:
                 key_string, *constraints = key_string.split('|')
                 if CONSTANTS.DEBUG: 
                     print(f"D1: Constraints for {key_string}: {constraints}")
-                temp_delays = []
+                temp_constraints = []
                 # constraints = []
                 for constraint in constraints:
                     if constraint.startswith('('):
                         # clean the brackets
                         constraint = constraint[1:-1]
-                        temp_delays.append(constraint)
+                        temp_constraints.append(constraint)
                     else:
-                        temp_delays.append(int(constraint))
-                constraints = temp_delays
+                        temp_constraints.append(int(constraint))
+                constraints = temp_constraints
                 
             else:
                 constraints = [self._arg_manager.ALIAS_MAX_DELAY_IN_MS, self._arg_manager.ALIAS_MIN_DELAY_IN_MS]
@@ -498,7 +502,9 @@ class FST_Keyboard():
                         # if reset code then ignore result for activation
                         if key.vk_code < 0:
                             if constraints_fulfilled:
-                                self.reset_macro_sequence_by_reset_code(key.vk_code, trigger_group)
+                                macro = self._macros_dict[trigger_group]
+                                self.reset_macro_sequence_by_alias[macro.alias]
+                                #self.reset_macro_sequence_by_reset_code(key.vk_code, trigger_group)
                         else:
                             activated = activated and constraints_fulfilled
             return activated    
@@ -599,7 +605,9 @@ class FST_Keyboard():
                                     
                                     # handling of reset codes for macro sequences in rebinds
                                     elif current_ke.vk_code <= 0:
-                                        self.reset_macro_sequence_by_reset_code(current_ke.vk_code)
+                                        macro = self._macros_dict[trigger_group]
+                                        self.reset_macro_sequence_by_alias[macro.alias]
+                                        #self.reset_macro_sequence_by_reset_code(current_ke.vk_code)
                                         to_be_suppressed = True
                                 break
                             
@@ -652,23 +660,8 @@ class FST_Keyboard():
                                 if len(key_sequence) == 0:
                                     pass
                                 elif len(key_sequence) > 0:
-                                    try:
-                                        macro_thread, stop_event = self._macro_thread_dict[trigger_group]
-                                        ## interruptable threads
-                                        if macro_thread.is_alive():
-                                            if CONSTANTS.DEBUG:
-                                                print(f"D1: {trigger_group}-macro: still alive - try to stop")
-                                            stop_event.set()
-                                            macro_thread.join()
-                                    except KeyError:
-                                        # this thread was not started before
-                                        pass
-                                    # reset stop event
-                                    stop_event = Event()
-                                    macro_thread = Macro_Thread(key_sequence, stop_event, trigger_group, self)
-                                    # save thread and stop event to find it again for possible interruption
-                                    self._macro_thread_dict[trigger_group] = [macro_thread, stop_event]
-                                    macro_thread.start() 
+                                    
+                                    self.start_macro_playback(macro.alias, key_sequence) 
                                     
                                 if CONSTANTS.DEBUG:
                                     print("D1: > playing makro:", trigger_group)
@@ -779,6 +772,26 @@ class FST_Keyboard():
             
         if CONSTANTS.DEBUG4:
             print(f"D4: {"-- | <-" if is_simulated else "<-"} OUT ({key_event_time - FST_Keyboard.START_TIME}): {current_ke } - {"simulated key: " if is_simulated else "real key: "}")
+
+    def start_macro_playback(self, alias_name, key_sequence, stop_event = Event()):
+        try:
+            macro_thread, stop_event = self._macro_thread_dict[alias_name]
+                                        ## interruptable threads
+            if macro_thread.is_alive():
+                if CONSTANTS.DEBUG:
+                    print(f"D1: {alias_name}-macro: still alive - try to stop")
+                stop_event.set()
+                macro_thread.join()
+        except KeyError:
+                                        # this thread was not started before
+            pass
+                                    # reset stop event
+                          
+        stop_event.clear()
+        macro_thread = Macro_Thread(key_sequence, stop_event, alias_name, self)
+                                    # save thread and stop event to find it again for possible interruption
+        self._macro_thread_dict[alias_name] = [macro_thread, stop_event]
+        macro_thread.start()
                         
 
     def check_for_combination(self, vk_codes):                 
@@ -877,35 +890,35 @@ class FST_Keyboard():
             print(f"--- No Macro Sequence with name {alias_name} - reset failed")
         
         
-    def reset_macro_sequence_by_reset_code(self, vk_code, trigger_group = None):
+    # def reset_macro_sequence_by_reset_code(self, vk_code, trigger_group = None):
         
-        reset_code = vk_code
-        print(f"reset code played: {reset_code}")
-        # reset current trigger of this event - return this code to alias tread
-        try:
-            try:
-                # reset self macro sequence
-                if reset_code == -255:
-                    if trigger_group is None:
-                        print("ERROR: self reset only possible from the macro sequence to be reseted")
-                    else:
-                        self._macros_dict[trigger_group].reset_sequence_counter()
-                # reset every sequence counter
-                elif reset_code == -256:
-                    for trigger_group in self._macro_triggers:
-                        self._macros_dict[trigger_group].reset_sequence_counter()
-                        _, stop_event = self._macro_thread_dict[trigger_group]
-                        stop_event.set()
-                # reset a specific macro seq according to index
-                else:
-                    self._macros_dict[self._macro_triggers[reset_code]].reset_sequence_counter()
-                    _, stop_event = self._macro_thread_dict[self._macro_triggers[reset_code]]
-                    stop_event.set()
+    #     reset_code = vk_code
+    #     print(f"reset code played: {reset_code}")
+    #     # reset current trigger of this event - return this code to alias tread
+    #     try:
+    #         try:
+    #             # reset self macro sequence
+    #             if reset_code == -255:
+    #                 if trigger_group is None:
+    #                     print("ERROR: self reset only possible from the macro sequence to be reseted")
+    #                 else:
+    #                     self._macros_dict[trigger_group].reset_sequence_counter()
+    #             # reset every sequence counter
+    #             elif reset_code == -256:
+    #                 for trigger_group in self._macro_triggers:
+    #                     self._macros_dict[trigger_group].reset_sequence_counter()
+    #                     _, stop_event = self._macro_thread_dict[trigger_group]
+    #                     stop_event.set()
+    #             # reset a specific macro seq according to index
+    #             else:
+    #                 self._macros_dict[self._macro_triggers[reset_code]].reset_sequence_counter()
+    #                 _, stop_event = self._macro_thread_dict[self._macro_triggers[reset_code]]
+    #                 stop_event.set()
                         
-            except KeyError as error:
-                print(f"reset_all: macro thread for trigger {error} not found")
-        except IndexError:
-                print(f"wrong index for reset - no macro with index: {reset_code}")
+    #         except KeyError as error:
+    #             print(f"reset_all: macro thread for trigger {error} not found")
+    #     except IndexError:
+    #             print(f"wrong index for reset - no macro with index: {reset_code}")
 
     def apply_start_args_by_focus_name(self, focus_name = ''):
         

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -665,6 +665,7 @@ class FST_Keyboard():
                                     pass
                                 elif len(key_sequence) > 0:
                                     
+                                    
                                     self.start_macro_playback(macro.alias, key_sequence) 
                                     
                                 if CONSTANTS.DEBUG:
@@ -779,14 +780,15 @@ class FST_Keyboard():
 
     def start_macro_playback(self, alias_name, key_sequence, stop_event = Event()):
         try:
-            macro_thread, stop_event = self._macro_thread_dict[alias_name]
+            macro_thread, stop_event_old = self._macro_thread_dict[alias_name]
              ## interruptable threads
             if macro_thread.is_alive():
                 if CONSTANTS.DEBUG:
                     print(f"D1: {alias_name}-macro: still alive - try to stop")
-                stop_event.set()
+                stop_event_old.set()
                 macro_thread.join()
         except KeyError:
+            print(f"macro stop unsucessful - could not find Macro {alias_name}")
              # this thread was not started before
             pass
             # reset stop event

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -155,7 +155,7 @@ class FST_Keyboard():
             if '|' in key_string:
                 key_string, *constraints = key_string.split('|')
                 if CONSTANTS.DEBUG: 
-                    print(f"D1: delays for {key_string}: {constraints}")
+                    print(f"D1: Constraints for {key_string}: {constraints}")
                 temp_delays = []
                 # constraints = []
                 for constraint in constraints:

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -605,12 +605,14 @@ class FST_Keyboard():
                                     if not constraints_fulfilled:
                                         to_be_suppressed = True
                                     
+                                    ###XXX 241013-1754 deactivate
+                                    ### check_constraint takes over this function
                                     # handling of reset codes for macro sequences in rebinds
-                                    elif current_ke.vk_code <= 0:
-                                        macro = self._macros_dict[trigger_group]
-                                        self.reset_macro_sequence_by_alias[macro.alias]
-                                        #self.reset_macro_sequence_by_reset_code(current_ke.vk_code)
-                                        to_be_suppressed = True
+                                    # elif current_ke.vk_code <= 0:
+                                    #     macro = self._macros_dict[trigger_group]
+                                    #     self.reset_macro_sequence_by_alias[macro.alias]
+                                    #     #self.reset_macro_sequence_by_reset_code(current_ke.vk_code)
+                                    #     to_be_suppressed = True
                                 break
                             
                     if key_replaced and not to_be_suppressed:                     

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -319,6 +319,8 @@ class FST_Keyboard():
                 
                 if new_macro.num_sequences > 1: 
                     if alias != '':
+                        # self._macros_alias_dict[alias] = new_macro
+                        ###XXX 241013-0021 tobe able to use ke|(alias) for reset
                         self._macros_alias_dict[alias[1:-1]] = new_macro
                     else:
                         ### XXX 241011-1756
@@ -776,18 +778,21 @@ class FST_Keyboard():
     def start_macro_playback(self, alias_name, key_sequence, stop_event = Event()):
         try:
             macro_thread, stop_event = self._macro_thread_dict[alias_name]
-                                        ## interruptable threads
+             ## interruptable threads
             if macro_thread.is_alive():
                 if CONSTANTS.DEBUG:
                     print(f"D1: {alias_name}-macro: still alive - try to stop")
                 stop_event.set()
                 macro_thread.join()
         except KeyError:
-                                        # this thread was not started before
+             # this thread was not started before
             pass
-                                    # reset stop event
-                          
-        stop_event.clear()
+            # reset stop event
+        
+        ###XXX 241013-1421
+        if stop_event.is_set():
+            stop_event.clear()
+        # stop_event = Event()
         macro_thread = Macro_Thread(key_sequence, stop_event, alias_name, self)
                                     # save thread and stop event to find it again for possible interruption
         self._macro_thread_dict[alias_name] = [macro_thread, stop_event]
@@ -887,8 +892,10 @@ class FST_Keyboard():
             macro_to_reset.reset_sequence_counter()
             print(f"--- Macro ({alias_name}) reseted successfully by {current_ke}")
         except KeyError:
+            
             print(f"--- No Macro Sequence with name {alias_name} - reset failed")
-        
+            if CONSTANTS.DEBUG:
+                print(f"all sequence names: {self._macros_alias_dict.keys()}")
         
     # def reset_macro_sequence_by_reset_code(self, vk_code, trigger_group = None):
         

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -282,7 +282,6 @@ class FST_Keyboard():
                 # if both are key_events create ke:ke
                 if not both_are_Keys:
                     trigger_group = Key_Group(new_trigger_group)
-                    ###XXX 241011-1000
                     new_rebind = Rebind(trigger_group, replacement_key)
                     self._rebinds.append(new_rebind)
                     self._rebind_triggers.append(trigger_group)
@@ -293,7 +292,6 @@ class FST_Keyboard():
                     replacement_events = replacement_key.get_key_events()
                     for index in [0,1]:
                         trigger_group = Key_Group([trigger_events[index]] + trigger_rest)
-                        ###XXX 241011-1000
                         new_rebind = Rebind(trigger_group, replacement_events[index])
                         self._rebinds.append(new_rebind)
                         self._rebind_triggers.append(new_rebind.trigger_group)
@@ -319,11 +317,8 @@ class FST_Keyboard():
                 
                 if new_macro.num_sequences > 1: 
                     if alias != '':
-                        # self._macros_alias_dict[alias] = new_macro
-                        ###XXX 241013-0021 tobe able to use ke|(alias) for reset
                         self._macros_alias_dict[alias[1:-1]] = new_macro
                     else:
-                        ### XXX 241011-1756
                         # will not be displayed because the human readable collectors do not know this xD
                         auto_alias = f"seq_{num}"
                         self._macros_alias_dict[auto_alias] = new_macro
@@ -582,10 +577,8 @@ class FST_Keyboard():
                         
                         if is_trigger_activated(current_ke, trigger_group):
                             try:
-                                ###XXX 241011-1014
                                 rebind = self._rebinds_dict[trigger_group]
                                 replacement_ke = rebind.replacement
-                                # replacement_ke = self._rebinds_dict[trigger_group]
                                 old_ke = current_ke
                                 current_ke = replacement_ke
                                 key_replaced = True
@@ -605,14 +598,6 @@ class FST_Keyboard():
                                     if not constraints_fulfilled:
                                         to_be_suppressed = True
                                     
-                                    ###XXX 241013-1754 deactivate
-                                    ### check_constraint takes over this function
-                                    # handling of reset codes for macro sequences in rebinds
-                                    # elif current_ke.vk_code <= 0:
-                                    #     macro = self._macros_dict[trigger_group]
-                                    #     self.reset_macro_sequence_by_alias[macro.alias]
-                                    #     #self.reset_macro_sequence_by_reset_code(current_ke.vk_code)
-                                    #     to_be_suppressed = True
                                 break
                             
                     if key_replaced and not to_be_suppressed:                     
@@ -784,7 +769,7 @@ class FST_Keyboard():
              ## interruptable threads
             if macro_thread.is_alive():
                 if CONSTANTS.DEBUG:
-                    print(f"D1: {alias_name}-macro: still alive - try to stop")
+                    print(f"D1: {alias_name} is still alive - trying to stop")
                 stop_event_old.set()
                 macro_thread.join()
         except KeyError:
@@ -793,12 +778,11 @@ class FST_Keyboard():
             pass
             # reset stop event
         
-        ###XXX 241013-1421
         if stop_event.is_set():
             stop_event.clear()
         # stop_event = Event()
         macro_thread = Macro_Thread(key_sequence, stop_event, alias_name, self)
-                                    # save thread and stop event to find it again for possible interruption
+        # save thread and stop event to find it again for possible interruption
         self._macro_thread_dict[alias_name] = [macro_thread, stop_event]
         macro_thread.start()
                         
@@ -825,10 +809,9 @@ class FST_Keyboard():
                 self.control_toggle_pause()
                 
         'RESET ON ESC AND ALT+TAB'
-        # TODO: as key_event? 'release_all_pressed_keys' -> as invocation was easier -> |(stop_all_repeat())
         if self.check_for_combination(['esc']):
             self.state_manager.release_all_currently_pressed_keys()
-            self.state_manager.stop_all_repeating_keys()
+            # self.state_manager.stop_all_repeating_keys()
         if self.check_for_combination(['alt', 'tab']):
             self.state_manager.release_all_currently_pressed_keys()
 
@@ -900,36 +883,6 @@ class FST_Keyboard():
             print(f"--- No Macro Sequence with name {alias_name} - reset failed")
             if CONSTANTS.DEBUG:
                 print(f"all sequence names: {self._macros_alias_dict.keys()}")
-        
-    # def reset_macro_sequence_by_reset_code(self, vk_code, trigger_group = None):
-        
-    #     reset_code = vk_code
-    #     print(f"reset code played: {reset_code}")
-    #     # reset current trigger of this event - return this code to alias tread
-    #     try:
-    #         try:
-    #             # reset self macro sequence
-    #             if reset_code == -255:
-    #                 if trigger_group is None:
-    #                     print("ERROR: self reset only possible from the macro sequence to be reseted")
-    #                 else:
-    #                     self._macros_dict[trigger_group].reset_sequence_counter()
-    #             # reset every sequence counter
-    #             elif reset_code == -256:
-    #                 for trigger_group in self._macro_triggers:
-    #                     self._macros_dict[trigger_group].reset_sequence_counter()
-    #                     _, stop_event = self._macro_thread_dict[trigger_group]
-    #                     stop_event.set()
-    #             # reset a specific macro seq according to index
-    #             else:
-    #                 self._macros_dict[self._macro_triggers[reset_code]].reset_sequence_counter()
-    #                 _, stop_event = self._macro_thread_dict[self._macro_triggers[reset_code]]
-    #                 stop_event.set()
-                        
-    #         except KeyError as error:
-    #             print(f"reset_all: macro thread for trigger {error} not found")
-    #     except IndexError:
-    #             print(f"wrong index for reset - no macro with index: {reset_code}")
 
     def apply_start_args_by_focus_name(self, focus_name = ''):
         

--- a/fst_manager.py
+++ b/fst_manager.py
@@ -113,7 +113,9 @@ class Output_Manager():
         else:
             delay_times = delay_times[:2]
         
-        self.send_key_event(key_event)
+        ###XXX 241013-1803 prevent all internal vk_codees from being executed
+        if key_event.vk_code > 0:
+            self.send_key_event(key_event)
         
         if self._fst.arg_manager.ACT_DELAY and with_delay:
             delay_time = self.get_random_delay(*delay_times)
@@ -386,8 +388,8 @@ class Output_Manager():
         #         raise KeyError(error)
         #     return True
         
-        def test(a,b,c):
-            print(f"received: {a}, {b} and {c}")
+        # def test(a,b,c):
+        #     print(f"received: {a}, {b} and {c}")
 
         # --------------------
         
@@ -1144,7 +1146,9 @@ class Focus_Group_Manager():
             self._focus_thread.pause()
         
     def start_focus_thread(self):
-        if self.focus_active:
+        if self._focus_thread.is_alive():
+            pass
+        elif self.focus_active:
             self._focus_thread.start()
         
     def restart_focus_thread(self):

--- a/fst_manager.py
+++ b/fst_manager.py
@@ -34,7 +34,6 @@ class CONSTANTS():
 
 
 class Output_Manager():
-    
     '''
     #XXX
     '''
@@ -611,6 +610,8 @@ class Config_Manager():
         default_start_arguments = []
         default_group_lines = []
         alias_lines = []
+
+        
         
         for line in cleaned_lines:
             if line.startswith('<focus>'):
@@ -637,8 +638,6 @@ class Config_Manager():
                     line = line.replace(alias, '').strip()
                 else:
                     alias = ''
-                    
-                    
                 if focus_name == '':
                     default_group_lines.append([alias, line])
                 else:
@@ -786,6 +785,10 @@ class Config_Manager():
         self._macros_hr = []
         self._alias_hr = []
         
+        count_tap = 1
+        count_rebind = 1
+        count_macro = 1
+        count_macro_sequence = 1
         # sort the lines into their categories for later initialization
         for line in lines:    
 
@@ -797,13 +800,19 @@ class Config_Manager():
                 groups = line.split(':')
                 # tap groups
                 if len(groups) == 1: 
+                    # generate default names for Tap Groups
+                    if alias == '':
+                        alias = f"(TAP_{count_tap})"
+                        count_tap += 1
                     self._tap_groups_hr.append([alias, split_ignore_brackets(groups[0])])
                 # rebinds
                 elif len(groups) == 2:
                     trigger_group = split_ignore_brackets(groups[0])
                     key_group = split_ignore_brackets(groups[1])
-                    # rebind
-                    # if len(trigger_group) == 1 and len(key_group) == 1:
+                    # generate default names for Rebinds
+                    if alias == '':
+                        alias = f"(REB_{count_rebind})"
+                        count_rebind += 1
                     if len(key_group) == 1:
                         self._rebinds_hr.append([alias, [trigger_group, key_group[0]]])
                     else:
@@ -813,46 +822,84 @@ class Config_Manager():
                 elif len(groups) > 2 and len(groups[1]) == 0:
                     trigger_group = split_ignore_brackets(groups[0])
                     if len(groups) > 3:
-                        # for group in groups[2:]:
-                        #     trigger_group.append(group.split(','))
+                        # generate default names for Macro Sequences
+                        if alias == '':
+                            alias = f"(SEQ_{count_macro_sequence})"
+                            count_macro_sequence += 1
+                        
                         key_groups = [split_ignore_brackets(group) for group in groups[2:]]
                         self._macros_hr.append([alias, [trigger_group] + key_groups])
                     else:
+                        # generate default names for Macros
+                        if alias == '':
+                            alias = f"(MAC_{count_macro})"
+                            count_macro += 1
                         key_group = split_ignore_brackets(groups[2])
                         self._macros_hr.append([alias, [trigger_group, key_group]])
+                    
+    # def display_groups(self):
+    #     """
+    #     Display the current tap groups.
+    #     """
+    #     # alias display
+    #     print("# Aliases")
+    #     for alias_group in self._alias_hr:
+    #         alias, group = alias_group
+    #         print(f"{alias} " + ', '.join(group)+'')         
+    #     # tap groups
+    #     print("\n# Tap Groups")
+    #     for tap_group in self._tap_groups_hr:
+    #         alias, tap_group = tap_group
+    #         print(f"{alias} " + ', '.join(tap_group)+'')         
+    #     # rebinds
+    #     print("\n# Rebinds")
+    #     for rebind in self._rebinds_hr:
+    #         alias, rebind = rebind
+    #         print(f"{alias} " + ' : '.join([', '.join(rebind[0]), rebind[1]]))
+    #     # macros
+    #     print("\n# Macros")
+    #     for group in self._macros_hr:
+    #         alias, *group = group
+    #         group = group[0]
+    #         first_line = f"{alias} " + ' :: '.join([', '.join(group[0]),', '.join(group[1])])
+    #         position = first_line.find('::')
+    #         print(first_line)
+    #         if len(group) > 2:
+    #             for gr in group[2:]:
+    #                 print(" " * (position+1) + ": " + ', '.join(gr))
                     
     def display_groups(self):
         """
         Display the current tap groups.
         """
         # alias display
+        
+        inset = '     '
+        
         print("# Aliases")
-        for index, alias_group in enumerate(self._alias_hr):
+        for alias_group in self._alias_hr:
             alias, group = alias_group
             print(f"{alias} " + ', '.join(group)+'')         
         # tap groups
         print("\n# Tap Groups")
-        for index, tap_group in enumerate(self._tap_groups_hr):
+        for tap_group in self._tap_groups_hr:
             alias, tap_group = tap_group
-            # print(f"{tap_group}\n")
-            print(f"[{index}]{alias} " + ', '.join(tap_group)+'')         
+            print(f"{alias} " + ', '.join(tap_group)+'')         
         # rebinds
         print("\n# Rebinds")
-        for index, rebind in enumerate(self._rebinds_hr):
+        for rebind in self._rebinds_hr:
             alias, rebind = rebind
-            # print(f"[{index}] " + ' : '.join([rebind[0], rebind[1]]))
-            print(f"[{index}]{alias} " + ' : '.join([', '.join(rebind[0]), rebind[1]]))
+            print(f"{alias} " + ' : '.join([', '.join(rebind[0]), rebind[1]]))
         # macros
         print("\n# Macros")
-        for index, group in enumerate(self._macros_hr):
+        for group in self._macros_hr:
             alias, *group = group
             group = group[0]
-            first_line = f"[{index}]{alias} " + ' :: '.join([', '.join(group[0]),', '.join(group[1])])
-            position = first_line.find('::')
+            first_line = f"{alias} " + f' \n{inset}:: '.join([', '.join(group[0]),', '.join(group[1])])
             print(first_line)
             if len(group) > 2:
                 for gr in group[2:]:
-                    print(" " * (position+1) + ": " + ', '.join(gr))
+                    print(f"{inset} : " + ', '.join(gr))
 
     def add_group(self, new_group, data_object):
         """
@@ -1041,22 +1088,6 @@ class Argument_Manager():
             else:
                 print("unknown start argument: ", arg)
 
-    # def apply_start_args_by_focus_name(self, focus_name = ''):
-        
-    #     self.apply_start_arguments(self.sys_start_args)
-        
-    #     self._fst.update_focus_groups()
-    #     ###XXX 241011-1409
-    #     # self._fst.focus_manager.update_groups_from_config(self._fst.config_manager.load_config())
-    #     # self._fst.config_manager.load_config()
-    #     # needs to be done after reloading of file or else it will not have the actual data
-    #     if focus_name != '':
-    #         focus_start_arguments, _ = self._fst.focus_manager.multi_focus_dict[focus_name]
-    #     else:
-    #         focus_start_arguments, _ = [],[]
-            
-    #     self.apply_start_arguments(self._fst.focus_manager.default_start_arguments + focus_start_arguments)
-
 class Focus_Group_Manager():
     '''
     #XXX
@@ -1074,7 +1105,6 @@ class Focus_Group_Manager():
         self.focus_active = False
         self._focus_thread  = None
     
-        ###XXX 241011-1218
         self._alias_group_lines = []
         
     @property

--- a/fst_threads.py
+++ b/fst_threads.py
@@ -62,7 +62,7 @@ class Alias_Repeat_Thread(Thread):
     '''
     repeatatly execute a key event based on a timer
     '''
-    def __init__(self, alias_name, repeat_time, stop_event, fst_keyboard, time_increment=500):
+    def __init__(self, alias_name, repeat_time, stop_event, fst_keyboard, time_increment=100):
         Thread.__init__(self)
         self.daemon = True
         self.alias_name = alias_name
@@ -74,34 +74,29 @@ class Alias_Repeat_Thread(Thread):
         self.reset = False
         self.macro_stop_event = Event()
         
-        
-        
+         
     def run(self): 
         print(f"START REPEAT: {self.alias_name} with interval of {self.repeat_time} ms")
 
         while not self.stop_event.is_set():
             if self.reset:
+                ###XXX241013-1422
+                # the the macro thread has a chance to register set before clear
+                sleep(0.01)
                 self.macro_stop_event.clear()
+                # self.macro_stop_event = Event
                 self.reset = False
                 print(f"{self.alias_name} reset")
             else:
                 print(f"{self.alias_name} execute")
-                
-                
                 self._fst.start_macro_playback(self.alias_name, self._fst.key_group_by_alias[self.alias_name], self.macro_stop_event)
-                
-                # starte ich ein alias thread??
-                # soll er interruptable sein?
-                
-                # if self._fst.output_manager.check_constraint_fulfillment(self.key_event):
-                #     self._fst.output_manager.execute_key_event(self.key_event)
-                
             for index in range(self.number_of_increments):
-                if not self.stop_event.is_set() and not self.reset:
-                    sleep(self.time_increment / 1000)
-                else:
+                if self.stop_event.is_set() or self.reset:
+                    self.macro_stop_event.set()        
                     break
-        
+                else:
+                    sleep(self.time_increment / 1000)
+        # if stopped also stop the macro if it is still running
         print(f"STOP REPEAT: {self.alias_name} with interval of {self.repeat_time} ms")
                 
     def reset_timer(self):

--- a/fst_threads.py
+++ b/fst_threads.py
@@ -43,16 +43,17 @@ class Macro_Thread(Thread):
                 if self.stop_event.is_set():
                     break
                 else:
-                    vk_code = key_event.vk_code
-                    if vk_code <= 0:
+                    ###XXX 241013-1758 deactivate - eval takes over reset function by name
+                    # vk_code = key_event.vk_code
+                    # if vk_code <= 0:
 
-                        self._fst.reset_macro_sequence_by_alias(self.alias_name)
-                        # self._fst.reset_macro_sequence_by_reset_code(vk_code, self.alias_name)
-                    else:
-                        if key_event.is_toggle:
-                            key_event = self._fst.output_manager.get_next_toggle_state_key_event(key_event)
-                        # send key event and handles interruption of delay
-                        self._fst.output_manager.execute_key_event(key_event, delay_times, with_delay=True, stop_event=self.stop_event)
+                    #     self._fst.reset_macro_sequence_by_alias(self.alias_name)
+                    #     # self._fst.reset_macro_sequence_by_reset_code(vk_code, self.alias_name)
+                    # else:
+                    if key_event.is_toggle:
+                        key_event = self._fst.output_manager.get_next_toggle_state_key_event(key_event)
+                    # send key event and handles interruption of delay
+                    self._fst.output_manager.execute_key_event(key_event, delay_times, with_delay=True, stop_event=self.stop_event)
                        
         except Exception as error:
             print(error)
@@ -82,7 +83,7 @@ class Alias_Repeat_Thread(Thread):
             if self.reset:
                 ###XXX241013-1422
                 # the the macro thread has a chance to register set before clear
-                sleep(0.01)
+                sleep(0.05)
                 self.macro_stop_event.clear()
                 # self.macro_stop_event = Event
                 self.reset = False
@@ -103,42 +104,6 @@ class Alias_Repeat_Thread(Thread):
         self.macro_stop_event.set()
         self.reset = True
         
-# class Repeat_Thread(Thread):
-#     '''
-#     repeatatly execute a key event based on a timer
-#     '''
-#     def __init__(self, key_event, stop_event, time, fst_keyboard, time_increment=500):
-#         Thread.__init__(self)
-#         self.daemon = True
-#         vk_code, is_press, constraints = key_event.get_all()
-#         self.key_event = Key_Event(vk_code, is_press, constraints=constraints[1:], key_string=key_event.key_string)
-#         self.stop_event = stop_event
-#         self.time = time
-#         self.time_increment = time_increment
-#         self.number_of_increments = time // time_increment
-#         self.reset = False
-#         self._fst = fst_keyboard
-        
-#     def run(self): 
-#         print(f"START REPEAT: {self.key_event} with interval of {self.time} ms")
-
-#         while not self.stop_event.is_set():
-#             if self.reset:
-#                 self.reset = False
-#             else:
-#                 if self._fst.output_manager.check_constraint_fulfillment(self.key_event):
-#                     self._fst.output_manager.execute_key_event(self.key_event)
-                
-#             for index in range(self.number_of_increments):
-#                 if not self.stop_event.is_set() and not self.reset:
-#                     sleep(self.time_increment / 1000)
-#                 else:
-#                     break
-        
-#         print(f"STOP REPEAT: {self.key_event} with interval of {self.time} ms")
-                
-#     def reset_timer(self):
-#         self.reset = True
             
 class Focus_Thread(Thread):
     '''

--- a/fst_threads.py
+++ b/fst_threads.py
@@ -41,6 +41,7 @@ class Macro_Thread(Thread):
             for key_event, delay_times in to_be_played_key_events:
                 # alias_thread_logging.append(f"{time() - starttime:.5f}: Send virtual key: {key_event.key_string}")
                 if self.stop_event.is_set():
+                    self.stop_event.clear()
                     break
                 else:
                     ###XXX 241013-1758 deactivate - eval takes over reset function by name
@@ -74,6 +75,7 @@ class Alias_Repeat_Thread(Thread):
         self._fst = fst_keyboard
         self.reset = False
         self.macro_stop_event = Event()
+        # self.macro_return_event = Event()
         
          
     def run(self): 
@@ -83,17 +85,24 @@ class Alias_Repeat_Thread(Thread):
             if self.reset:
                 ###XXX241013-1422
                 # the the macro thread has a chance to register set before clear
-                sleep(0.05)
-                self.macro_stop_event.clear()
-                # self.macro_stop_event = Event
+                # sleep(0.05)
+                # self.macro_stop_event.clear()
+                
+                ###XXX 241013-2002
+                # if not self.macro_stop_event.is_set():
+                #     print("replacing macro stop event after self clearing")
+                #     self.macro_stop_event = Event()
+                self.macro_stop_event = Event()
                 self.reset = False
                 print(f"{self.alias_name} reset")
             else:
                 print(f"{self.alias_name} execute")
                 self._fst.start_macro_playback(self.alias_name, self._fst.key_group_by_alias[self.alias_name], self.macro_stop_event)
             for index in range(self.number_of_increments):
-                if self.stop_event.is_set() or self.reset:
-                    self.macro_stop_event.set()        
+                if self.stop_event.is_set():
+                    self.macro_stop_event.set()
+                    break
+                elif self.reset:
                     break
                 else:
                     sleep(self.time_increment / 1000)

--- a/fst_threads.py
+++ b/fst_threads.py
@@ -3,10 +3,10 @@ Free-Snap-Tap V1.1
 last updated: 241010-0028
 '''
 
-from threading import Thread # to play aliases without interfering with keyboard listener
+from threading import Thread, Event # to play aliases without interfering with keyboard listener
 from time import sleep # sleep(0.005) = 5 ms
 import pygetwindow as gw # to get name of actual window for focusapp function
-from fst_data_types import Key_Event
+
 
 
 alias_thread_logging = []
@@ -15,12 +15,12 @@ class Macro_Thread(Thread):
     '''
     execute macros/alias in its own threads so the delay is not interfering with key evaluation
     '''
-    def __init__(self, key_group, stop_event, trigger_group, fst_keyboard):
+    def __init__(self, key_group, stop_event, alias_name, fst_keyboard):
         Thread.__init__(self)
         self.daemon = True
         self.key_group = key_group
         self.stop_event = stop_event
-        self.trigger_group = trigger_group
+        self.alias_name = alias_name
         self._fst = fst_keyboard
         
     def run(self): 
@@ -28,7 +28,7 @@ class Macro_Thread(Thread):
         try:   
             # Key_events ans Keys here ...
             if self._fst.arg_manager.DEBUG2:
-                print(f"D2: > playing macro: {self.trigger_group} :: {self.key_group}")
+                print(f"D2: > playing macro: {self.alias_name} :: {self.key_group}")
             for key_event in self.key_group:
                 
                 # check all constraints at start!
@@ -45,7 +45,9 @@ class Macro_Thread(Thread):
                 else:
                     vk_code = key_event.vk_code
                     if vk_code <= 0:
-                        self._fst.reset_macro_sequence_by_reset_code(vk_code, self.trigger_group)
+
+                        self._fst.reset_macro_sequence_by_alias(self.alias_name)
+                        # self._fst.reset_macro_sequence_by_reset_code(vk_code, self.alias_name)
                     else:
                         if key_event.is_toggle:
                             key_event = self._fst.output_manager.get_next_toggle_state_key_event(key_event)
@@ -56,31 +58,43 @@ class Macro_Thread(Thread):
             print(error)
             alias_thread_logging.append(error)
 
-class Repeat_Thread(Thread):
+class Alias_Repeat_Thread(Thread):
     '''
     repeatatly execute a key event based on a timer
     '''
-    def __init__(self, key_event, stop_event, time, fst_keyboard, time_increment=500):
+    def __init__(self, alias_name, repeat_time, stop_event, fst_keyboard, time_increment=500):
         Thread.__init__(self)
         self.daemon = True
-        vk_code, is_press, constraints = key_event.get_all()
-        self.key_event = Key_Event(vk_code, is_press, constraints=constraints[1:], key_string=key_event.key_string)
+        self.alias_name = alias_name
+        self.repeat_time = repeat_time
         self.stop_event = stop_event
-        self.time = time
         self.time_increment = time_increment
-        self.number_of_increments = time // time_increment
-        self.reset = False
+        self.number_of_increments = self.repeat_time // time_increment
         self._fst = fst_keyboard
+        self.reset = False
+        self.macro_stop_event = Event()
+        
+        
         
     def run(self): 
-        print(f"START REPEAT: {self.key_event} with interval of {self.time} ms")
+        print(f"START REPEAT: {self.alias_name} with interval of {self.repeat_time} ms")
 
         while not self.stop_event.is_set():
             if self.reset:
+                self.macro_stop_event.clear()
                 self.reset = False
+                print(f"{self.alias_name} reset")
             else:
-                if self._fst.output_manager.check_constraint_fulfillment(self.key_event):
-                    self._fst.output_manager.execute_key_event(self.key_event)
+                print(f"{self.alias_name} execute")
+                
+                
+                self._fst.start_macro_playback(self.alias_name, self._fst.key_group_by_alias[self.alias_name], self.macro_stop_event)
+                
+                # starte ich ein alias thread??
+                # soll er interruptable sein?
+                
+                # if self._fst.output_manager.check_constraint_fulfillment(self.key_event):
+                #     self._fst.output_manager.execute_key_event(self.key_event)
                 
             for index in range(self.number_of_increments):
                 if not self.stop_event.is_set() and not self.reset:
@@ -88,10 +102,48 @@ class Repeat_Thread(Thread):
                 else:
                     break
         
-        print(f"STOP REPEAT: {self.key_event} with interval of {self.time} ms")
+        print(f"STOP REPEAT: {self.alias_name} with interval of {self.repeat_time} ms")
                 
     def reset_timer(self):
+        self.macro_stop_event.set()
         self.reset = True
+        
+# class Repeat_Thread(Thread):
+#     '''
+#     repeatatly execute a key event based on a timer
+#     '''
+#     def __init__(self, key_event, stop_event, time, fst_keyboard, time_increment=500):
+#         Thread.__init__(self)
+#         self.daemon = True
+#         vk_code, is_press, constraints = key_event.get_all()
+#         self.key_event = Key_Event(vk_code, is_press, constraints=constraints[1:], key_string=key_event.key_string)
+#         self.stop_event = stop_event
+#         self.time = time
+#         self.time_increment = time_increment
+#         self.number_of_increments = time // time_increment
+#         self.reset = False
+#         self._fst = fst_keyboard
+        
+#     def run(self): 
+#         print(f"START REPEAT: {self.key_event} with interval of {self.time} ms")
+
+#         while not self.stop_event.is_set():
+#             if self.reset:
+#                 self.reset = False
+#             else:
+#                 if self._fst.output_manager.check_constraint_fulfillment(self.key_event):
+#                     self._fst.output_manager.execute_key_event(self.key_event)
+                
+#             for index in range(self.number_of_increments):
+#                 if not self.stop_event.is_set() and not self.reset:
+#                     sleep(self.time_increment / 1000)
+#                 else:
+#                     break
+        
+#         print(f"STOP REPEAT: {self.key_event} with interval of {self.time} ms")
+                
+#     def reset_timer(self):
+#         self.reset = True
             
 class Focus_Thread(Thread):
     '''

--- a/fst_threads.py
+++ b/fst_threads.py
@@ -44,13 +44,6 @@ class Macro_Thread(Thread):
                     self.stop_event.clear()
                     break
                 else:
-                    ###XXX 241013-1758 deactivate - eval takes over reset function by name
-                    # vk_code = key_event.vk_code
-                    # if vk_code <= 0:
-
-                    #     self._fst.reset_macro_sequence_by_alias(self.alias_name)
-                    #     # self._fst.reset_macro_sequence_by_reset_code(vk_code, self.alias_name)
-                    # else:
                     if key_event.is_toggle:
                         key_event = self._fst.output_manager.get_next_toggle_state_key_event(key_event)
                     # send key event and handles interruption of delay
@@ -74,24 +67,13 @@ class Alias_Repeat_Thread(Thread):
         self.number_of_increments = self.repeat_time // time_increment
         self._fst = fst_keyboard
         self.reset = False
-        self.macro_stop_event = Event()
-        # self.macro_return_event = Event()
-        
+        self.macro_stop_event = Event()        
          
     def run(self): 
         print(f"START REPEAT: {self.alias_name} with interval of {self.repeat_time} ms")
 
         while not self.stop_event.is_set():
             if self.reset:
-                ###XXX241013-1422
-                # the the macro thread has a chance to register set before clear
-                # sleep(0.05)
-                # self.macro_stop_event.clear()
-                
-                ###XXX 241013-2002
-                # if not self.macro_stop_event.is_set():
-                #     print("replacing macro stop event after self clearing")
-                #     self.macro_stop_event = Event()
                 self.macro_stop_event = Event()
                 self.reset = False
                 print(f"{self.alias_name} reset")

--- a/vk_codes.py
+++ b/vk_codes.py
@@ -196,7 +196,7 @@ vk_codes_dict = {
     
     # none key that will never be executed but constraints will be evaluated 
     # to add reset or repeat with extra constraint checks
-    'none': 0, 'NONE': 0, 'None': 0, 'null': 0, 'nil': 0, 'zero': 0,
+    'none': 0, 'NONE': 0, 'None': 0,
     
     ###XXX 241013-1812
     'reset': "not supported anymore - use reset evaluation |(*name to reset*)",

--- a/vk_codes.py
+++ b/vk_codes.py
@@ -1,6 +1,6 @@
 # Dictionary mapping strings and keys to their VK codes
-# just add your own key strings and vk_codes by using the "3. print virtual key codes to identify keys." of the menu
-# and write them into the dictionary. There is no problem if there are multiple key_strings for the same vk_code.
+# just add your own key strings, identify the vk_codes by using the "3. print virtual key codes to identify keys." of the menu
+# and write them into the dictionary. It is no problem if there are multiple key_strings for the same vk_code.
 vk_codes_dict = {
     # mouse keys
     'mouse_left': 1,   'left_mouse': 1,   'ml': 1, 
@@ -194,44 +194,52 @@ vk_codes_dict = {
     
     # -----------------only for internal usage --------------------
     
+    # none key that will never be executed but constraints will be evaluated 
+    # to add reset or repeat with extra constraint checks
+    'none': 0, 'NONE': 0, 'None': 0, 'null': 0, 'nil': 0, 'zero': 0,
+    
+    ###XXX 241013-1812
+    'reset': "not supported anymore - use reset evaluation |(*name to reset*)",
     
     # supress keys with binding to:
     'suppress': -999,
     
+    
+    ###XXX 241013-1800 reset is taken over by evaluation -> use |(*name of sequence to reset*)
     # reset macro sequences
-    'reset' : -255, # always resets the active macro
-    'reset_all': -256,
-    'reset_0': 0,
-    'reset_1': -1,
-    'reset_2': -2,
-    'reset_3': -3,
-    'reset_4': -4,
-    'reset_5': -5,
-    'reset_6': -6,
-    'reset_7': -7,
-    'reset_8': -8,
-    'reset_9': -9,
-    'reset_10': -10,
-    'reset_11': -11,
-    'reset_12': -12,
-    'reset_13': -13,
-    'reset_14': -14,
-    'reset_15': -15,
-    'reset_16': -16,
-    'reset_17': -17,
-    'reset_18': -18,
-    'reset_19': -19,
-    'reset_20': -20,
-    'reset_21': -21,
-    'reset_22': -22,
-    'reset_23': -23,
-    'reset_24': -24,
-    'reset_25': -25,
-    'reset_26': -26,
-    'reset_27': -27,
-    'reset_28': -28,
-    'reset_29': -29,
-    'reset_30': -30,
+    # 'reset' : -255, # always resets the active macro
+    # 'reset_all': -256,
+    # 'reset_0': 0,
+    # 'reset_1': -1,
+    # 'reset_2': -2,
+    # 'reset_3': -3,
+    # 'reset_4': -4,
+    # 'reset_5': -5,
+    # 'reset_6': -6,
+    # 'reset_7': -7,
+    # 'reset_8': -8,
+    # 'reset_9': -9,
+    # 'reset_10': -10,
+    # 'reset_11': -11,
+    # 'reset_12': -12,
+    # 'reset_13': -13,
+    # 'reset_14': -14,
+    # 'reset_15': -15,
+    # 'reset_16': -16,
+    # 'reset_17': -17,
+    # 'reset_18': -18,
+    # 'reset_19': -19,
+    # 'reset_20': -20,
+    # 'reset_21': -21,
+    # 'reset_22': -22,
+    # 'reset_23': -23,
+    # 'reset_24': -24,
+    # 'reset_25': -25,
+    # 'reset_26': -26,
+    # 'reset_27': -27,
+    # 'reset_28': -28,
+    # 'reset_29': -29,
+    # 'reset_30': -30,
     
 
 }

--- a/vk_codes.py
+++ b/vk_codes.py
@@ -196,7 +196,7 @@ vk_codes_dict = {
     
     # none key that will never be executed but constraints will be evaluated 
     # to add reset or repeat with extra constraint checks
-    'none': 0, 'NONE': 0, 'None': 0,
+    'none': 0, 'NONE': 0, 'None': 0, '': 0, '_': 0,
     
     ###XXX 241013-1812
     'reset': "not supported anymore - use reset evaluation |(*name to reset*)",


### PR DESCRIPTION
## V1.1.1

builds up on top of V1.1.0 - so see there for how the write aliases and name macros

###NEW
- **Repeating of Alias Groups**
  - `ke|(toggle_repeat('<*name of alias*>, *time in ms*)` - e.g. `ke|(toggle_repeat('<scan_alias>, 6000)`
  - repeated alias work the same as macros
    - playback can be interrupted by stopping, toggling on/off and resetting
  - entirely independent of the key_event it follows as constraint
  - if used in rebind, use it on a ke with a prefix (`-` or `+`) or else it will be started as press and release
    - use new `None` key_event (description see below) 
      - e.g. `-None|*constraint to be fulfilled*|(toggle_repeat('<*name of alias*>, *time in ms*)`
  - can not be used in tap_groups, can be used anywhere else where constraints can be used 
  - alias will be played like a macro:
    - constraints checked at start and with defined delays
  - repeat_time in ms is the time between 2 playbacks of the same alias as macro
    - if macro delays are longer than the repeat_time, the restart of the repeat will interrupt the previous repeat  
  - multiple repeats can be started from the same key_event
- repeating can be control via following Evaluations:
  -  all will evaluate to true and only be evaluated if previous constraints are True
  - `ke|(toggle_repeat('<*name of alias*>, *repeat time in ms*)`
  - `ke|(start_repeat('<*name of alias*>, *repeat time in ms*)`
  - `ke|(stop_repeat('<*name of alias*>)`
  - `ke|(reset_repeat('<*name of alias*>)`
  - `ke|(stop_all_repeat()`

### General
- FROM NOW ON: **ALL evaluation will always evaluate to True** 
  - if key_event should not be played add a `|(False)` constraint at the end or use `None` key_event
  - it is just simpler to keep in mind if all will result in True
- `None` = `none` = `NONE` = `*empty*` = `_` key_event that will never be played but the constraints will be evaluated (included delay)
  - use it as reset replacement with the name of the Seq as constraint or for Alias Repeat Evaluations 
  - *empty* -> e.g. `... , |(reset('sequence')), ...`
- default Names for Tap_Groups, Rebinds and Macros if no name is given (name is needed by macros to interrupt itself)
  - names for macros MUST be unique and if used in other macros they will interrupting each other 
- updated display of Macros and Macro Sequences: trigger group will be displayed on line with name of macro, key groups will each have its own line
- Evaluation can now also be used with functions calls that include commas - e.g. |(pow(2 , 2) can now be used to define now complex functions to calculate times (a byproduct of implementing alias repeat)

### breaking changes to reset handling
- the previously in V1.1.0 introduced syntax for reset a Macro Sequence via Evaluation is now the only allowed way to do it
  - `ke|(*name of macro sequence to be reset*)`
  - `None|(reset('sequence'))` or simply `... , |(reset('sequence')), ...` also possible - a bit more verbose
  - can also be combined with previous constraints to only reset if they evaluate to True
  - `None` key_event should be convenient replacement `None|constraint|(*sequence_name*)`
- removed all reset vk_codes
  - `reset`, `reset_all`, `reset_*number*`
  - using any of them will result in an Error

```bash
<hello> x|400,y|400
-z : -z|(toggle_repeat('<hello>', 2000))
-u : -u|(reset_repeat('<hello>'))
(stop all repeat on esc) -esc : -esc|(stop_all_repeat())

(sequence) a :: b : c : d : e
(reset of it) d : d|(sequence)
(alternate reset via None) tab :: +shift, tab, None|(reset('sequence'))
(alternate reset via empty ke) tab :: +shift, tab, |(reset('sequence'))

```
See Release Notes on V1.1.0 for the other changes