### PR TITLE
V1.1.5 bugfixes

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,29 @@
+## V1.1.5 changelog
+
+241028-1323
+bugfix:
+- when active window returned empty the script crashed 
+  - fixed
+- evaluations with python code that hat spaces in it like (not is_set('var')) were not recognized correctly 
+  - fixed
+- if a line in the config file started with whitespaces and could lead to wrong recognition of start arguments and commented out lines
+  - leading whitespaces will now be removed
+  - fixed
+- automatic shortening of active window name removed the name of e.g. the game because of some versioning info following it. So if the last part of the window name is not the game name, then it could happen that the game name would be removed
+  - now it will always check the full name for the focus name 
+  - removed shortening due to many possible naming schemes
+  - fixed 
+
+added:
+- eval `|(is_repeat_active('aliasname'))` -> True or False dependent on if a repeat is active
+
+
+changed
+- changed default value of set to 1 and clear to 0 (in python 0 -> False and 1 -> True)
+  - to always work in variables with numbers and not mix numbers and boolean values
+- status_indicator now starts with red as default and only changes when focus name is recognized
+- cleaned up some code for the drawing of the status_indicator
+
 ## V1.1.4 main_testing branch Changelog
 241023-1055
 - removed some debug output

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -12,8 +12,6 @@ import tkinter as tk
 from fst_keyboard import FST_Keyboard
 from fst_manager import CONSTANTS
 
-
-
 # will not overwrite debug settings in config
 CONSTANTS.DEBUG = False
 # CONSTANTS.DEBUG = True
@@ -26,11 +24,11 @@ CONSTANTS.DEBUG3 = False
 CONSTANTS.DEBUG_NUMPAD = False
 # CONSTANTS.DEBUG_NUMPAD = True
 
+
 # Define File name for saving of everything, can be any filetype
 # But .txt or .cfg recommended for easier editing
 CONSTANTS.FILE_NAME = 'FSTconfig.txt'
 # CONSTANTS.FILE_NAME = 'FSTconfig_test.txt'
-
 
 # Control key combinations (vk_code and/or key_string) 
 # (1,2 or more keys possible - depends on rollover of your keyboard)
@@ -44,6 +42,10 @@ class Status_Indicator():
     def __init__(self, root, fst_keyboard):
         self.root = root
         self._fst = fst_keyboard
+        self.crosshair_enabled = False
+        self.crosshair = None
+        self.stop = False
+        
         self.root.title("FST Status Indicator")
         self.root.overrideredirect(True)  # Remove window decorations
         
@@ -51,23 +53,32 @@ class Status_Indicator():
         self.screen_width = self.root.winfo_screenwidth()
         self.screen_height = self.root.winfo_screenheight()
         
-        # Calculate the position to center the window
-        self.x_position = (self.screen_width) - 60
-        self.y_position = 0
+        # Calculate the size and position of the window
+        user_size = self._fst.arg_manager.STATUS_INDICATOR_SIZE
+        padding = 20
+        dpadding = 2* padding
+        x_size = dpadding + user_size
+        if x_size < 100:
+            x_size = 100
+        y_size = dpadding + user_size
+        x_position = (self.screen_width) - x_size
+        y_position = 0
         
-        # Set the window geometry to 2x2 pixels centered on the screen
-        self.root.geometry(f'100x100+{self.x_position}+{self.y_position}')
+        # Set the window geometry placement
+        self.root.geometry(f'{x_size}x{y_size}+{x_position}+{y_position}')
         self.root.attributes("-alpha", 0.5)  # Set transparency level
         self.root.wm_attributes("-topmost", 1)  # Keep the window on top
         self.root.wm_attributes("-transparentcolor", "yellow")
         
         # print(f"self._fst.arg_manager.STATUS_INDICATOR_SIZE: {self._fst.arg_manager.STATUS_INDICATOR_SIZE}")
         # Create a canvas for the indicator
-        self.canvas = tk.Canvas(self.root, width=100+self._fst.arg_manager.STATUS_INDICATOR_SIZE, height=100+self._fst.arg_manager.STATUS_INDICATOR_SIZE, bg='yellow', highlightthickness=0)
+        
+        
+        self.canvas = tk.Canvas(self.root, width=x_size, height=y_size, bg='yellow', highlightthickness=0)
         self.canvas.pack()
 
         # Draw the indicator
-        self.indicator = self.canvas.create_oval(20, 20, 20+self._fst.arg_manager.STATUS_INDICATOR_SIZE, 20+self._fst.arg_manager.STATUS_INDICATOR_SIZE, fill="green")
+        self.indicator = self.canvas.create_oval(x_size - padding - user_size, padding, x_size - padding, y_size - padding, fill="red")
 
         # Bind mouse events to make the window draggable
         self.root.bind("<ButtonPress-1>", self.on_start)
@@ -91,12 +102,6 @@ class Status_Indicator():
         
         # Bind right-click to show the context menu
         self.canvas.bind("<Button-3>", self.show_context_menu)
-        
-        self.crosshair_enabled = False
-        self.crosshair = None
-        
-        self.stop = False
-        
 
     def open_config_file(self, event = None):
         startfile(self._fst.config_manager.file_name)
@@ -105,8 +110,6 @@ class Status_Indicator():
         self._fst.update_args_and_groups(self._fst.focus_manager.FOCUS_APP_NAME)
         self._fst.cli_menu.update_group_display()
         print(f'\n>>> file reloaded for focus app: {self._fst.focus_manager.FOCUS_APP_NAME}\n')
-        
-
 
     def on_start(self, event):
         # Record the starting position of the mouse

--- a/fst_threads.py
+++ b/fst_threads.py
@@ -1,6 +1,6 @@
 '''
-Free-Snap-Tap V1.1.3
-last updated: 241015-1300
+Free-Snap-Tap V1.1.5
+last updated: 241105-2004
 '''
 
 from threading import Thread, Event # to play aliases without interfering with keyboard listener
@@ -72,7 +72,7 @@ class Macro_Thread(Thread):
             print(error)
             alias_thread_logging.append(error)
 
-class Alias_Repeat_Thread(Thread):
+class Macro_Repeat_Thread(Thread):
     '''
     repeatatly execute a key event based on a timer
     '''
@@ -131,48 +131,56 @@ class Focus_Thread(Thread):
 
     def run(self):
         last_active_window = ''
+        shortened_active_window = ''
         found_new_focus_app = False
         manually_paused = False
         while not self.stop:
             try:
-                active_window = gw.getActiveWindow().title
-
-                # shorten the active window name
-                if len(active_window) >= 25:
-                    reverse = active_window[::-1]
-                    del1 = reverse.find('–')
-                    del2 = reverse.find('-')
-                    del3 = reverse.find('/')
-                    del4 = reverse.find('\\')
-                    del_min = 100
-                    for deliminator in [del1, del2, del3, del4]:
-                        if deliminator != -1 and deliminator < del_min:
-                            del_min = deliminator 
-                    reverse_shortened = reverse[:del_min]
-                    active_window = reverse_shortened[::-1]
-                    if active_window[0] == ' ':
-                        active_window = active_window[1:]    
-                
+                active_window = gw.getActiveWindow().title               
             except AttributeError:
                 pass
             
-            if active_window not in ["FST Status Indicator", "FST Crosshair"]:
-                if not self.FOCUS_THREAD_PAUSED and not self._fst.arg_manager.MANUAL_PAUSED:
-        
-                    if active_window != last_active_window or manually_paused:
-                        if active_window != last_active_window:
-                            last_active_window = active_window
-                        # to make sure it activates ne focus setting even if manually paused in other app than resumed
-
+            if active_window != last_active_window or manually_paused:
+                if active_window != last_active_window:
+                    last_active_window = active_window
+                    
+                # shorten the active window name
+                ###XXX 241105-1858 
+                # if len(active_window) >= 25:
+                #     reverse = active_window[::-1]
+                #     del1 = reverse.find('–')
+                #     del2 = reverse.find('-')
+                #     del3 = reverse.find('/')
+                #     del4 = reverse.find('\\')
+                #     del_min = 100
+                #     for deliminator in [del1, del2, del3, del4]:
+                #         if deliminator != -1 and deliminator < del_min:
+                #             del_min = deliminator 
+                #     reverse_shortened = reverse[:del_min]
+                #     shortened_active_window = reverse_shortened[::-1].strip()
+                # else:
+                #     shortened_active_window = '--'
+                    
+                if active_window not in ["FST Status Indicator", "FST Crosshair"]:
+                    if not self.FOCUS_THREAD_PAUSED and not self._fst.arg_manager.MANUAL_PAUSED:
+            
                         if manually_paused:
                             manually_paused = False
                         
                         found_new_focus_app = False
                             
                         for focus_name in self._fst.focus_manager.multi_focus_dict_keys:
+                            # check the shortened window name
+                            # if shortened_active_window.lower().find(focus_name) >= 0:
+                            #     found_new_focus_app = True
+                            #     self._fst.focus_manager.FOCUS_APP_NAME = focus_name
+                            #     active_window = shortened_active_window
+                            #     break
+                            # check full window name
                             if active_window.lower().find(focus_name) >= 0:
                                 found_new_focus_app = True
                                 self._fst.focus_manager.FOCUS_APP_NAME = focus_name
+                                
                                 break
                                         
                         if found_new_focus_app:
@@ -199,10 +207,10 @@ class Focus_Thread(Thread):
                                 sleep(0.2)
                                 self._fst.arg_manager.WIN32_FILTER_PAUSED = True 
                                 print(f"> Active Window: {active_window}")
-                                        
-                        
-                else:
-                    manually_paused = True
+                                            
+                            
+                    else:
+                        manually_paused = True
                         
             sleep(0.5)
 

--- a/vk_codes.py
+++ b/vk_codes.py
@@ -7,9 +7,9 @@ last updated: 241015-1041
 # and write them into the dictionary. It is no problem if there are multiple key_strings for the same vk_code.
 vk_codes_dict = {
     # mouse keys
-    'mouse_left': 1,   'left_mouse': 1,   'ml': 1, 
-    'mouse_right': 2,  'right_mouse': 2,  'mr': 2, 
-    'mouse_middle': 3, 'middle_mouse': 3, 'mm': 3,
+    'mouse_left': 1,   'left_mouse': 1,   'ml': 1, 'lm': 1, 
+    'mouse_right': 2,  'right_mouse': 2,  'mr': 2, 'rm': 2, 
+    'mouse_middle': 3, 'middle_mouse': 3, 'mm': 3, 
     'mouse_x1': 4, 'mx1' : 4,
     'mouse_x2': 5, 'mx2' : 5,
     'scroll_vertical' : 6, 'scroll_vert' : 6, 'vert_scroll' : 6,


### PR DESCRIPTION
## V1.1.5 

### bugfix:
- when active window returned empty the script crashed 
  - fixed
- evaluations with python code that hat spaces in it like (not is_set('var')) were not recognized correctly 
  - fixed
- if a line in the config file started with white spaces and could lead to wrong recognition of start arguments and commented out lines
  - leading white spaces will now be removed
  - fixed
- automatic shortening of active window name removed the name of e.g. the game because of some versioning info following it. So if the last part of the window name is not the game name, then it could happen that the game name would be removed
  - now it will always check the full name for the focus name 
  - removed shortening due to many possible naming schemes
  - fixed 

### added:
- eval `|(is_repeat_active('aliasname'))` -> True or False dependent on if a repeat is active

### changed:
- changed default value of set to 1 and clear to 0 (in python 0 -> False and 1 -> True)
  - to always work in variables with numbers and not mix numbers and boolean values
- status_indicator now starts with red as default and only changes when focus name is recognized
- cleaned up some code for the drawing of the status_indicator