### PR TITLE
Toast box system

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -1,17 +1,40 @@
+260427-1400
+- added toast box for messages and timers
+  - added toast message function that will be displayed under the status indicator overlay, that will vanish after set duration (ms)
+    - show_message(*text*, *duration in s*, *text_size in px*, *background_color*, *text_color*)
+      - `_|(show_message("test"))` # minimal message shown for 3 s
+      - `_|(show_message("test", d=15, ts=15, bgc="green", tc="white"))`
+      - bgc und tc also usable via `bgc="rgba(40, 40, 40, 200)"` and thus with alpha (transparency)
+  - added timer toast message function that displays a countdown timer on the right side of the message text
+    - `-up :: _|(show_timer("test", d=15, ts=15, bgc="green"))`
+  - example with usage of alias use the same formatting for different timers
+    ```
+      # alias for timer that can be used for different timer when in combination with `get_var` and `set_var`
+      <timer> _|(show_timer(get_var("text"), d=get_var("dur"), ts=15, bgc="rgba(40, 200, 40, 200)", tc="white"))
+      -up :: _|(set_var("text","UPPPP 15"))|(set_var("dur",15)), <timer>
+      -left :: _|(set_var("text","LEFFT 10"))|(set_var("dur",10)), <timer>
+      -right :: <timer>
+      -down :: _|(show_message("test", d=15, ts=15, bgc="green"))
+    ```
+- added function `get_var` and `set_var` for arbitrary variable assignments
+  - if `get_var` is called before `set_var`, then the variable will be set to the string "None"
+- added test_overlay.py for easier testing of the gui
+
+
 260426-2158
 - mouse scrolling added via functions:
-  - vertical scrolling: `_|(scroll_up("value"))`, `_|(scroll_down("value"))`
-  - horizontal scrolling: `_|(scroll_left("value"))`, `_|(scroll_right("value"))`
-  - e.g. `-up :: _|(scroll_up("value"))`
+  - vertical scrolling: `_|(scroll_up(*value*))`, `_|(scroll_down(*value*))`
+  - horizontal scrolling: `_|(scroll_left(*value*))`, `_|(scroll_right(*value*))`
+  - e.g. `-up :: _|(scroll_up(*value*))`
 - mouse movement added via functions:
   - relative movement from current positon:
-    - `_|(mouse_move("dx", "dy"))`
+    - `_|(mouse_move(*dx*, *dy*))`
     - `-up ::    _|(mouse_move(0,-50))`
     - `-left ::  _|(mouse_move(-50,0))`
     - `-down ::  _|(mouse_move(0,50))`
     - `-right :: _|(mouse_move(50,0))`
   - absolute movement:
-    - `_|(mouse_move_abs("dx", "dy"))`
+    - `_|(mouse_move_abs(*dx*, *dy*))`
 - function `mouse_get_pos()` added that will print out current absolut position and copy the tuble of coordinates into the clipboard of windows for easier pasting
 
 260426-1856

--- a/change_log.md
+++ b/change_log.md
@@ -1,16 +1,44 @@
+ideas:
+- toast timer upgrade resolution from 1s to 0.1s
+- asyncio integration instead of threading for macros and repeat functions
+  - potential to greatly reduce threading and running conditions (even if not very often problematic)
+  - remove the use of time.sleep and thus blocking behavior
+- MouseOnMove maybe usable to record relative mouse movement to record anit recoil movement in games? :_)
+- transition some global control variables like PAUSED and STOPPED to an Event System?
+  - Thread safety
+- maybe rethink how i control the UI update loop??
+  - Focus_Thread
+- replace the improvised DEBUG variable system with actual logging
+- make the config possible to be split into multiple files
+  - maybe a folder and one file per focus group?
+
+
+260428-1230
+- fixed a bug in reset_repeat logic that lead to an entire repeat time with no action before starting again
+- integrated in repeat function the toast message as timer
+  - can optionally be disabled via with_overlay=0 in function
+  - `start_repeat(alias_string, repeat_time, with_overlay=0)`
+- added remove function for toasts, which is used by the repeat function if reset to prematurely restart a loop
+  - works semi reliable on the repeat - has problems with to many repeat or with to fast restarts of a repeat and will generate multiple toasts
+  - added function `remove_toast(text, immediately=0)` and `remove_all_toasts(immediately=0)` for deleting toasts manually
+    - `immediately=1` will remove toast immediately
+    - `immediately=0` default value will recolor toast red and display DEL at timer area, will be removed 1 second after recoloring
+- added checks if status_indicator is even on before a toast/timer is posted
+
 260427-2009
-- Add several utility actions to Output_Manager: 
-  - `get_time` # in ms since epoch
-  - `mouse_get_pos` # return tuble of x,y coordinate of current mouse position and copies it into clipboard for easier pasting
-  - `mouse_save_to_var`
-  - `mouse_move_to_var`
-  - `copy_to_clipboard`
-  - `paste`
-  - `save_into_file`
-  - `append_to_file`
-  - `empty_file`
-  - `print_all_variables`
-  - `clear_console`
+- Add several utility actions/functions to Output_Manager: 
+  - `get_time()` # in ms since epoch
+  - `mouse_get_pos()` # return tuple (x,y) coordinate of current mouse position and copies it into clipboard for easier pasting
+  - `mouse_save_to_var(var)` # saves the tuple in a variable
+  - `mouse_move_to_var(var)` # moves to the variable if it is a valid tuple
+  - `copy_to_clipboard(var)` # copies selected variable to os clipboard
+  - `paste()` # returns what is in the clipbaord for use in functions 
+    - (not sure for what yet, but when you have a copy to clipboard then why not a paste also? :-P)
+  - `save_into_file(text, time_stamp=get_time(), mode='w', file_path='output.txt')` # "{time_stamp}: {text}" saved into {file_path}')
+  - `append_to_file(text, time_stamp=get_time(), file_path='output.txt')` #
+  - `empty_file(file_path='output.txt')`
+  - `print_all_variables()`
+  - `clear_console()`
 - Show toast messages when starting/stopping repeats and when making/restoring backups. 
 - Update make_backup/restore_backup to return both path and name, and adjust fst_save_file_handler to return (path, name) tuples. A
 - lso import time alongside datetime.

--- a/change_log.md
+++ b/change_log.md
@@ -1,3 +1,20 @@
+260427-2009
+- Add several utility actions to Output_Manager: 
+  - `get_time` # in ms since epoch
+  - `mouse_get_pos` # return tuble of x,y coordinate of current mouse position and copies it into clipboard for easier pasting
+  - `mouse_save_to_var`
+  - `mouse_move_to_var`
+  - `copy_to_clipboard`
+  - `paste`
+  - `save_into_file`
+  - `append_to_file`
+  - `empty_file`
+  - `print_all_variables`
+  - `clear_console`
+- Show toast messages when starting/stopping repeats and when making/restoring backups. 
+- Update make_backup/restore_backup to return both path and name, and adjust fst_save_file_handler to return (path, name) tuples. A
+- lso import time alongside datetime.
+
 260427-1400
 - added toast box for messages and timers
   - added toast message function that will be displayed under the status indicator overlay, that will vanish after set duration (ms)

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -9,7 +9,7 @@ from time import sleep
 
 from fst_keyboard import FST_Keyboard
 from fst_manager import CONSTANTS
-from fst_overlay import GUI_Manager, set_console_visibility
+from fst_overlay import GUI_Manager, set_console_visibility, ToastBridge
 from PySide6.QtWidgets import QApplication
 import datetime
 
@@ -133,6 +133,11 @@ if __name__ == "__main__":
         main_thread.start()
         app = QApplication([])
         gui_manager = GUI_Manager(fst_keyboard, app=app)
+        
+        bridge = ToastBridge()
+        bridge.signal_show_toast.connect(gui_manager.show_message)
+        fst_keyboard.toast_callback = bridge.trigger_toast
+        
 
         if fst_keyboard.arg_manager.TRAY_ICON:
             gui_manager.tray_icon.show()

--- a/free_snap_tap.py
+++ b/free_snap_tap.py
@@ -135,9 +135,17 @@ if __name__ == "__main__":
         gui_manager = GUI_Manager(fst_keyboard, app=app)
         
         bridge = ToastBridge()
-        bridge.signal_show_toast.connect(gui_manager.show_message)
-        fst_keyboard.toast_callback = bridge.trigger_toast
         
+        # Connect bridge signals to GUI manager slots
+        bridge.signal_show_toast.connect(gui_manager.toast_manager.add_toast)
+        bridge.signal_show_timer.connect(gui_manager.toast_manager.add_timer)
+        bridge.signal_remove_toast.connect(gui_manager.toast_manager.remove_toast)
+        bridge.signal_remove_all_toasts.connect(gui_manager.toast_manager.remove_all_toasts)
+        # Inject the bridge methods into the keyboard logic for thread-safe calls
+        fst_keyboard.toast_callback = bridge.trigger_toast
+        fst_keyboard.timer_callback = bridge.trigger_timer
+        fst_keyboard.remove_callback = bridge.trigger_remove
+        fst_keyboard.remove_all_callback = bridge.trigger_remove_all
 
         if fst_keyboard.arg_manager.TRAY_ICON:
             gui_manager.tray_icon.show()

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -54,7 +54,8 @@ class FST_Keyboard():
         self._cli_menu = CLI_menu(self)
         
         self.toast_callback = None # Will hold bridge.trigger_toast   
-
+        self.timer_callback = None # Will hold bridge.trigger_timer
+        self.remove_callback = None # Will hold bridge.remove_toast
         
         # Tap groups define which keys are mutually exclusive
         # Key Groups define which key1 will be replaced by key2

--- a/fst_keyboard.py
+++ b/fst_keyboard.py
@@ -53,6 +53,9 @@ class FST_Keyboard():
         self._state_manager = Input_State_Manager(self)
         self._cli_menu = CLI_menu(self)
         
+        self.toast_callback = None # Will hold bridge.trigger_toast   
+
+        
         # Tap groups define which keys are mutually exclusive
         # Key Groups define which key1 will be replaced by key2
         # if a Key Group has more than 2 keys if will be handled als alias

--- a/fst_manager.py
+++ b/fst_manager.py
@@ -12,7 +12,7 @@ from random import randint # randint(3, 9))
 from time import time, sleep # sleep(0.005) = 5 ms
 from fst_data_types import Key_Event, type_check
 from fst_threads import Focus_Thread, Macro_Repeat_Thread
-import datetime
+import datetime, time
 import re #regular expression
 from fst_save_file_handler import make_backup as mb, restore_backup as rb
 import pyperclip # to copy mouse position to clipboard for easier pasting
@@ -345,6 +345,7 @@ class Output_Manager():
             repeat_thread = Macro_Repeat_Thread(alias_string, repeat_time, stop_event, self._fst)
             self._repeat_thread_dict[alias_string] = [repeat_thread, stop_event]
             repeat_thread.start() 
+            show_message(f"Started repeat for {alias_string} with {repeat_time} ms", d=3., ts=12, bgc="rgba(40, 150, 40, 200)")
             return True
             
         def toggle_repeat(alias_string, repeat_time):
@@ -373,6 +374,7 @@ class Output_Manager():
                 if CONSTANTS.DEBUG3:
                     print(f"can not find a Repeat called {alias_string} - stop_repeat()")
                 # raise KeyError(error)
+            show_message(f"Stopped repeat for {alias_string}", d=3., ts=12, bgc="rgba(150, 40, 40, 200)")
             return True
         
         def is_repeat_active(alias_string):
@@ -532,19 +534,26 @@ class Output_Manager():
             current_date_time = datetime.datetime.now().strftime("%y%m%d-%H%M")
             return current_date_time
         
+        #get current time in ms since epoch
+        def get_time():
+            current_time = int(time() * 1000)
+            return current_time
+        
         def release_modifier():
             self._fst.state_manager.release_all_modifier_keys()
             
         def make_backup(save_dir=self._fst.arg_manager.SAVE_DIR, backup_root_dir=self._fst.arg_manager.BACKUP_ROOT_DIR):
-            backup_path = mb(save_dir, backup_root_dir)
+            backup_path, backup_name = mb(save_dir, backup_root_dir)
             print(f"Made backup to {backup_path}")
+            show_message(f"Made backup to {backup_name}", d=5., ts=10, bgc="rgba(40, 150, 40, 200)")
             if CONSTANTS.DEBUG4:
                 print(f"D4: -- Eval: made backup to {backup_path}")
             return True
         
         def restore_backup(save_dir=self._fst.arg_manager.SAVE_DIR, backup_root_dir=self._fst.arg_manager.BACKUP_ROOT_DIR):
-            restored_path = rb(save_dir, backup_root_dir)
+            restored_path, restored_name = rb(save_dir, backup_root_dir)
             print(f"Restored backup from {restored_path}")
+            show_message(f"Restored backup from {restored_name}", d=5., ts=10, bgc="rgba(150, 40, 40, 200)")
             if CONSTANTS.DEBUG4:
                 print(f"D4: -- Eval: restored backup from {restored_path}")
             return True
@@ -575,10 +584,28 @@ class Output_Manager():
         
         def mouse_get_pos():
             position = self._mouse_controller.position
-            print(f"{position} copied to clipboard")
-            # save in clipboard for easier pasting            
-            pyperclip.copy(f"{position}")  
+            copy_to_clipboard(f"{position}")
+            return position
+        
+        def mouse_save_to_var(key_string):
+            position = mouse_get_pos()
+            self.variables[key_string] = position
+            print(f'mouse position {position} saved to variable {key_string}')
             return True
+        
+        def mouse_move_to_var(key_string):
+            try:
+                position = self.variables[key_string]
+                if isinstance(position, tuple) and len(position) == 2:
+                    self._mouse_controller.position = position
+                    print(f'mouse moved to position {position} from variable {key_string}')
+                    return True
+                else:
+                    print(f'variable {key_string} does not contain a valid position')
+                    return False
+            except KeyError:
+                print(f'variable {key_string} not found')
+                return False
         
         # show_message(*text*, *duration in s*, *text_size in px*, *background_color*, *text_color*)
         def show_message(text, d=3., ts=12, bgc="rgba(40, 150, 40, 200)", tc="white"):
@@ -601,6 +628,47 @@ class Output_Manager():
                 print(f'variable {key_string} set to "None"')
                 return self.variables[key_string]
             
+        def copy_to_clipboard(key_string):
+            pyperclip.copy(key_string)
+            show_message(f'"{key_string}" copied to clipboard')
+            return True
+        
+        def paste():
+            pasted_text = pyperclip.paste()
+            print(f'"{pasted_text}" pasted from clipboard')
+            return pasted_text
+        
+        def save_into_file(text, time_stamp=get_time(), mode='w', file_path='output.txt'):
+            with open(file_path, mode) as file:
+                file.write(f"{time_stamp}: {text}\n")
+            print(f'"{time_stamp}: {text}" saved into {file_path}')
+            return True
+        
+        def append_to_file(text, time_stamp=get_time(), file_path='output.txt'):
+            return save_into_file(text, time_stamp, mode='a', file_path=file_path)
+        
+        def empty_file(file_path='output.txt'):
+            open(file_path, 'w').close()
+            print(f'{file_path} has been emptied')
+            return True
+        
+        def print_all_variables():
+            if self.variables:
+                print("Current variables:")
+                for key_string, value in self.variables.items():
+                    print(f"{key_string}: {value}")
+            else:
+                print("No variables set.")
+            return True
+        
+        def clear_console():
+            if sys.platform.startswith('win'):
+                system('cls')
+            else:
+                system('clear')
+            return True
+        
+        
         # ---------------------------
         # eval starts from here
         

--- a/fst_manager.py
+++ b/fst_manager.py
@@ -12,7 +12,7 @@ from random import randint # randint(3, 9))
 from time import time, sleep # sleep(0.005) = 5 ms
 from fst_data_types import Key_Event, type_check
 from fst_threads import Focus_Thread, Macro_Repeat_Thread
-import datetime, time
+import datetime
 import re #regular expression
 from fst_save_file_handler import make_backup as mb, restore_backup as rb
 import pyperclip # to copy mouse position to clipboard for easier pasting
@@ -337,20 +337,21 @@ class Output_Manager():
                 ##2
                 return 9999
             
-        def start_repeat(alias_string, repeat_time):
+        def start_repeat(alias_string, repeat_time, with_overlay=1):
             stop_repeat(alias_string)
             
             repeat_time = int(repeat_time)
             stop_event = Event()
-            repeat_thread = Macro_Repeat_Thread(alias_string, repeat_time, stop_event, self._fst)
-            self._repeat_thread_dict[alias_string] = [repeat_thread, stop_event]
+            reset_event = Event()
+            repeat_thread = Macro_Repeat_Thread(alias_string, repeat_time, stop_event, reset_event, with_overlay, self._fst)
+            self._repeat_thread_dict[alias_string] = [repeat_thread, stop_event, reset_event]
             repeat_thread.start() 
-            show_message(f"Started repeat for {alias_string} with {repeat_time} ms", d=3., ts=12, bgc="rgba(40, 150, 40, 200)")
+            #show_message(f"Started repeat for {alias_string} with {repeat_time} ms", d=3., ts=12, bgc="rgba(40, 150, 40, 200)")
             return True
             
         def toggle_repeat(alias_string, repeat_time):
             try:
-                repeat_thread, stop_event = self._repeat_thread_dict[alias_string]
+                repeat_thread, stop_event, reset_event = self._repeat_thread_dict[alias_string]
                 if repeat_thread.is_alive():
                     # print(f"stopping repeat for {current_ke}")
                     stop_event.set()
@@ -366,7 +367,7 @@ class Output_Manager():
         
         def stop_repeat(alias_string):
             try:
-                repeat_thread, stop_event = self._repeat_thread_dict[alias_string]
+                repeat_thread, stop_event, reset_event = self._repeat_thread_dict[alias_string]
                 if repeat_thread.is_alive():
                     stop_event.set()
                     repeat_thread.join()
@@ -374,12 +375,12 @@ class Output_Manager():
                 if CONSTANTS.DEBUG3:
                     print(f"can not find a Repeat called {alias_string} - stop_repeat()")
                 # raise KeyError(error)
-            show_message(f"Stopped repeat for {alias_string}", d=3., ts=12, bgc="rgba(150, 40, 40, 200)")
+            #show_message(f"Stopped repeat for {alias_string}", d=3., ts=12, bgc="rgba(150, 40, 40, 200)")
             return True
         
         def is_repeat_active(alias_string):
             try:
-                repeat_thread, stop_event = self._repeat_thread_dict[alias_string]
+                repeat_thread, stop_event, reset_event = self._repeat_thread_dict[alias_string]
                 if repeat_thread.is_alive():
                     return True
                 else:
@@ -392,9 +393,9 @@ class Output_Manager():
         
         def reset_repeat(alias_string):
             try:
-                repeat_thread, _ = self._repeat_thread_dict[alias_string]
+                repeat_thread, _, reset_event = self._repeat_thread_dict[alias_string]
                 if repeat_thread.is_alive():
-                    repeat_thread.reset_timer()
+                    reset_event.set()
             except KeyError:
                 if CONSTANTS.DEBUG3:
                     print(f"can not find a Repeat called {alias_string} - reset_repeat()")
@@ -403,7 +404,7 @@ class Output_Manager():
         
         def stop_all_repeat():
             try:
-                for repeat_thread, stop_event in self._repeat_thread_dict.values():
+                for repeat_thread, stop_event, reset_event in self._repeat_thread_dict.values():
                     if repeat_thread.is_alive():
                         stop_event.set()
                         repeat_thread.join()
@@ -609,12 +610,22 @@ class Output_Manager():
         
         # show_message(*text*, *duration in s*, *text_size in px*, *background_color*, *text_color*)
         def show_message(text, d=3., ts=12, bgc="rgba(40, 150, 40, 200)", tc="white"):
-            self._fst.toast_callback(text, d, ts, bgc, tc, timer=0)
+            self._fst.toast_callback(text, d, ts, bgc, tc)
             return True
         
         def show_timer(text, d=3., ts=12, bgc="rgba(150, 150, 40, 200)", tc="white"):
-            self._fst.toast_callback(text, d, ts, bgc, tc, timer=1)
+            self._fst.timer_callback(text, d, ts, bgc, tc)
             return True
+        
+        def remove_toast(text, immediately=0):
+            self._fst.remove_callback(text)
+            return True
+        
+        def remove_all_toasts(immediately=0):
+            self._fst.remove_all_callbacks()
+            return True
+        
+        
 
         def set_var(key_string, text):
             self.variables[key_string] = text
@@ -1678,7 +1689,7 @@ class Input_State_Manager():
 
     def stop_all_repeating_keys(self):
         for key_event in self._fst.output_manager.repeat_thread_dict.keys():
-            repeat_thread, stop_event = self._fst.output_manager.repeat_thread_dict[key_event]
+            repeat_thread, stop_event, reset_event = self._fst.output_manager.repeat_thread_dict[key_event]
             if repeat_thread.is_alive():
                 stop_event.set()
                 repeat_thread.join()

--- a/fst_manager.py
+++ b/fst_manager.py
@@ -579,8 +579,28 @@ class Output_Manager():
             # save in clipboard for easier pasting            
             pyperclip.copy(f"{position}")  
             return True
+        
+        # show_message(*text*, *duration in s*, *text_size in px*, *background_color*, *text_color*)
+        def show_message(text, d=3., ts=12, bgc="rgba(40, 150, 40, 200)", tc="white"):
+            self._fst.toast_callback(text, d, ts, bgc, tc, timer=0)
+            return True
+        
+        def show_timer(text, d=3., ts=12, bgc="rgba(150, 150, 40, 200)", tc="white"):
+            self._fst.toast_callback(text, d, ts, bgc, tc, timer=1)
+            return True
 
-
+        def set_var(key_string, text):
+            self.variables[key_string] = text
+            return True
+            
+        def get_var(key_string):
+            try:
+                return self.variables[key_string]
+            except KeyError:
+                set_var(key_string, "None")
+                print(f'variable {key_string} set to "None"')
+                return self.variables[key_string]
+            
         # ---------------------------
         # eval starts from here
         

--- a/fst_overlay.py
+++ b/fst_overlay.py
@@ -243,9 +243,19 @@ class GUI_Manager(QWidget):
         else:
             self._fst.arg_manager.CROSSHAIR_ENABLED = True
         
-    def show_message(self, text, duration, text_size, bg_color, text_color, timer):
-            self.toast_manager.add_toast(text, duration, text_size, bg_color, text_color, timer)
             
+    # def add_toast(self, text, **kwargs):
+    #     self.toast_manager.add_toast(text, **kwargs)
+    
+    # def add_timer(self, text, **kwargs):
+    #     self.toast_manager.add_toast(text, **kwargs)
+        
+    # def remove_toast(self, text):
+    #     self.toast_manager.remove_toast(text)   
+    
+    # def remove_all_toasts(self):
+    #     self.toast_manager.remove_all_toasts()
+        
         
 class Tray_Icon(QSystemTrayIcon):
     """A system tray icon with a context menu for Free-Snap-Tap."""
@@ -626,18 +636,16 @@ class StatusOverlay(QWidget):
            
            
 class ToastWidget(QFrame):
-    def __init__(self, text, duration=3., text_size=12, bg_color="rgba(40, 40, 40, 200)", text_color="white", timer=0, parent=None):
+    def __init__(self, text, duration=3.0, text_size=12, bg_color="rgba(40, 40, 40, 200)", text_color="white", timer=0, parent=None):
         super().__init__(parent)
         self.setWindowFlags(Qt.FramelessWindowHint | Qt.ToolTip | Qt.WindowStaysOnTopHint)
-        #self.setAttribute(Qt.WA_TranslucentBackground)
         self.id = text
         self.base_text = text
-        # Convert ms duration to seconds for the countdown
-        self.duration = duration * 1000
-        self.remaining_seconds = self.duration // 1000
+        self.text_size = text_size
+        self.text_color = text_color
         
-        # This tells the widget: "Only be as wide as your text"
-        self.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
+        self.use_timer_display = bool(timer) # Store the flag
+        self.remaining_seconds = int(duration)
         
         self.setStyleSheet(f"""
             QFrame {{
@@ -645,7 +653,6 @@ class ToastWidget(QFrame):
                 color: {text_color};
                 border-radius: 8px;
                 padding: 0px;
-                /* border: 1px solid rgba(255, 255, 255, 40); */
             }}
             QLabel {{ 
                 background: transparent; 
@@ -656,38 +663,70 @@ class ToastWidget(QFrame):
         """)
 
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0) # Left, Top, Right, Bottom margins
-        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSizeConstraint(QVBoxLayout.SetFixedSize)
         
-        layout.setSizeConstraint(QVBoxLayout.SetFixedSize) # Crucial for tight framing
-        if timer:
+
+
+        # Set the initial text
+        if self.use_timer_display:
             self.label = QLabel(self.get_display_text())
         else:
             self.label = QLabel(f" {text} ")
         layout.addWidget(self.label)
+
+        # 2. Single Master Timer
+        # This handles both the countdown AND the eventual destruction
+        self.master_timer = QTimer(self)
+        self.master_timer.timeout.connect(self.handle_tick)
         
-        QTimer.singleShot(self.duration, self.deleteLater)
+        # Start at 1-second intervals
+        self.master_timer.start(1000) 
         
-        if timer:
-            if self.remaining_seconds > 0:
-                self.tick_timer = QTimer(self)
-                self.tick_timer.timeout.connect(self.update_countdown)
-                self.tick_timer.start(1000) # Trigger every 1 second
-            self.adjustSize()
-        
-    
+        self.adjustSize()
+
     def get_display_text(self):
-        """Formats the text to include the timer."""
-        
+        """Standardizes the countdown format."""
         return f" {self.base_text} | {self.remaining_seconds:3}s "
 
-    def update_countdown(self):
-        """Reduces the count and refreshes the label."""
+    def handle_tick(self):
+        """The single entry point for timer logic."""
         self.remaining_seconds -= 1
-        if self.remaining_seconds >= 0:
+        
+        if self.remaining_seconds <= 0:
+            self.master_timer.stop()
+            self.deleteLater()
+        elif self.use_timer_display: # No hasattr needed
             self.label.setText(self.get_display_text())
-            # Note: We don't need to call adjustSize() here unless 
-            # the character count changes drastically (e.g. 10s to 9s)
+
+    def dismiss(self, immediately):
+        """Visual confirmation before manual removal."""
+        if self.master_timer.isActive():
+            self.master_timer.stop()
+            
+        if immediately:
+            self.deleteLater()
+        else:
+            self.label.setText(f" {self.base_text} |  DEL ")
+            self.setStyleSheet(f"""
+                QFrame {{
+                    background-color: rgba(200, 40, 40, 200);
+                    color: {self.text_color};
+                    border-radius: 8px;
+                    padding: 0px;
+                }}
+                QLabel {{ 
+                    font-family: 'Consolas'; 
+                    font-size: {self.text_size}px; 
+                    font-weight: bold; 
+                }}
+            """)
+            
+            # Re-use the timer for the 1-second final delay
+            # This is more efficient than creating a singleShot
+            self.master_timer.timeout.disconnect() # Remove handle_tick
+            self.master_timer.timeout.connect(self.deleteLater)
+            self.master_timer.start(1000)
 
 class ToastManager(QWidget):
     def __init__(self, parent_overlay):
@@ -706,14 +745,52 @@ class ToastManager(QWidget):
         
         # Align children to the top-right of our static 500px box
         self.main_layout.setAlignment(Qt.AlignTop | Qt.AlignRight)
+        self.active_toasts = {} # Key: text (ID), Value: ToastWidget instance
 
-    def add_toast(self, text, duration, text_size, bg_color, text_color, timer):
-        toast = ToastWidget(text, duration, text_size, bg_color, text_color, timer)
-        self.main_layout.addWidget(toast, alignment=Qt.AlignRight)
+    def add_toast(self, text, duration, text_size, bg_color, text_color, timer=0):
+        # If a toast with the same ID already exists, remove it first
+        self.remove_toast(text, immediately=1)
+        if self._fst.arg_manager.STATUS_INDICATOR:
+            toast = ToastWidget(text, duration, text_size, bg_color, text_color, timer)
+            self.active_toasts[text] = toast
+            
+            # Auto-cleanup: remove from dict when the widget is deleted
+            toast.destroyed.connect(lambda: self._handle_destruction(text))
+            
+            self.main_layout.addWidget(toast, alignment=Qt.AlignRight)
+            self.update_position()
+            self.show()
         
-        # Position the manager once (it stays anchored)
+    def add_timer(self, text, duration, text_size, bg_color, text_color):
+        self.add_toast(text, duration, text_size, bg_color, text_color, timer=1)
+
+    def remove_toast(self, text, immediately=0):
+        """Manually find and delete a toast by its ID string."""
+        if text in self.active_toasts:
+            toast = self.active_toasts[text]
+            # deleteLater is safer than sip.delete for Qt widgets
+            toast.dismiss(immediately)  # Change text and color, then delete after 1 second
+            # We don't manually pop from dict here; 
+            # the 'destroyed' signal below handles it.
+            
+    def remove_all_toasts(self, immediately=0):
+        """Remove all active toasts using their individual dismiss logic."""
+        # .values() creates a view; list(...) creates a snapshot copy 
+        # so we don't have issues if the dict changes during iteration.
+        for toast in list(self.active_toasts.values()):
+            toast.dismiss(immediately)
+        
+        # Do NOT call self.active_toasts.clear() here.
+        # Each toast.dismiss() triggers a deleteLater(1000).
+        # When they actually vanish in 1 second, your _handle_destruction 
+        # method will pop them from the dict one by one.
+
+    def _handle_destruction(self, text):
+        """Internal cleanup when a toast disappears."""
+        if text in self.active_toasts:
+            self.active_toasts.pop(text)
+        self.check_empty()
         self.update_position()
-        self.show()
 
     def update_position(self):
         overlay_geo = self.parent_overlay.geometry()
@@ -732,8 +809,22 @@ class ToastManager(QWidget):
     
 class ToastBridge(QObject):
     # This acts as the thread-safe "translator"
-    signal_show_toast = Signal(str, int, int, str, str, int)  # text, duration, text_size, bg_color, text_color
+    signal_show_toast = Signal(str, int, int, str, str)  # text, duration, text_size, bg_color, text_color
+    signal_show_timer = Signal(str, int, int, str, str)  # text, duration, text_size, bg_color, text_color
+    signal_remove_toast = Signal(str, int) # New signal to target a specific ID
+    signal_remove_all_toasts = Signal(int) # New signal to remove all toasts
 
-    def trigger_toast(self, text, duration, text_size, bg_color, text_color, timer):
+    def trigger_toast(self, text, duration, text_size, bg_color, text_color):
         # This method can be called safely by ANY thread
-        self.signal_show_toast.emit(text, duration, text_size, bg_color, text_color, timer)
+        self.signal_show_toast.emit(text, duration, text_size, bg_color, text_color)
+
+    def trigger_timer(self, text, duration, text_size, bg_color, text_color):
+        self.signal_show_timer.emit(text, duration, text_size, bg_color, text_color)
+
+    def trigger_remove(self, text, immediately=0):
+        """Call this to instantly end a specific toast/timer."""
+        self.signal_remove_toast.emit(text, immediately)
+        
+    def trigger_remove_all(self, immediately=0):
+        """Call this to instantly end all toasts/timers."""
+        self.signal_remove_all_toasts.emit(immediately)  # Use a special wildcard ID to indicate "all"

--- a/fst_overlay.py
+++ b/fst_overlay.py
@@ -4,8 +4,8 @@ last updated: 250724-1434
 '''
 
 import sys
-from PySide6.QtWidgets import QWidget, QApplication, QMenu, QSystemTrayIcon
-from PySide6.QtCore import Qt, qInstallMessageHandler, Signal, QTimer
+from PySide6.QtWidgets import QSizePolicy, QWidget, QApplication, QMenu, QSystemTrayIcon, QLabel, QVBoxLayout, QFrame
+from PySide6.QtCore import QObject, Qt, qInstallMessageHandler, Signal, QTimer
 from PySide6.QtGui import QPainter, QColor, QPen, QCursor, QIcon, QPixmap, QFont
 
 import ctypes
@@ -56,25 +56,6 @@ def set_console_visibility(show: bool):
         user32.ShowWindow(hwnd, SW_HIDE)
         console_visible = False
 
-# # hide the console window of the overlay from the taskbar
-# def hide_overlay_console():
-    
-#     def get_window_by_title(title):
-#         # Set the return type and argument types for FindWindowW
-#         user32.FindWindowW.restype = ctypes.wintypes.HWND
-#         user32.FindWindowW.argtypes = [ctypes.wintypes.LPCWSTR, ctypes.wintypes.LPCWSTR]
-#         # Pass None for class name to match any window class
-#         hwnd = user32.FindWindowW(None, title)
-#         return hwnd
-
-#     hwnd = get_window_by_title("FST_Overlay")
-
-#     # Initialize style tracking on first use
-#     style = user32.GetWindowLongPtrW(hwnd, GWL_EXSTYLE)
-#    # Apply Win11-compatible hide
-#     new_style = (style & ~WS_EX_APPWINDOW) | WS_EX_TOOLWINDOW
-#     user32.SetWindowLongPtrW(hwnd, GWL_EXSTYLE, new_style)
-
 def get_current_screen():
     # center_point = self.geometry().center()
     # screen = QApplication.screenAt(center_point)
@@ -111,6 +92,8 @@ def get_device_pixel_ratio(screen):
 #         return multiplier 
 
     
+    
+    
 
 class GUI_Manager(QWidget):
     def __init__(self, fst_keyboard, app):
@@ -119,6 +102,7 @@ class GUI_Manager(QWidget):
         self._app = app
         self.tray_icon = Tray_Icon(fst_keyboard, parent=self)
         self.overlay = StatusOverlay(fst_keyboard, parent=self)
+        self.toast_manager = ToastManager(self.overlay)
         self.crosshair = CrosshairOverlay(fst_keyboard, parent=self)
         self.color = None
 
@@ -251,8 +235,6 @@ class GUI_Manager(QWidget):
     def display_internal_state(self):
         self._fst.display_internal_repr_groups()
         
-        
-        
     # --- Crosshair Toggle Logic ---
     def toggle_crosshair(self):
         if self._fst.arg_manager.CROSSHAIR_ENABLED:
@@ -261,6 +243,9 @@ class GUI_Manager(QWidget):
         else:
             self._fst.arg_manager.CROSSHAIR_ENABLED = True
         
+    def show_message(self, text, duration, text_size, bg_color, text_color, timer):
+            self.toast_manager.add_toast(text, duration, text_size, bg_color, text_color, timer)
+            
         
 class Tray_Icon(QSystemTrayIcon):
     """A system tray icon with a context menu for Free-Snap-Tap."""
@@ -452,7 +437,8 @@ class StatusOverlay(QWidget):
         self.counter = 0
         
         # Window appearance
-        self.padding = 5
+        self.base_padding = 5
+        self.user_padding = 5 # used also for other things, so that they scale together with the user size
         self.user_size = self._fst.arg_manager.STATUS_INDICATOR_SIZE
         self.setWindowTitle("FST Status Indicator")
         self.setWindowFlags(Qt.FramelessWindowHint | Qt.WindowStaysOnTopHint | Qt.Tool)
@@ -474,39 +460,28 @@ class StatusOverlay(QWidget):
         self.context_menu.addAction("Toggle Crosshair", self.signal_toggle_crosshair.emit)
         self.context_menu.addSeparator()
         self.context_menu.addAction("Hide Indicator", self.toggle_status_indicator)
-        
-        
-        # layout = QVBoxLayout()
-        # #layout.setContentsMargins(padding, padding, padding, padding)
-        # label = QLabel("FST", self)
-        # label.setAlignment(Qt.AlignCenter)
-        # label.setStyleSheet("color: white; font-weight: bold; font-size: 16px;")
-        # label.setFixedSize(user_size, user_size)
-        # layout.addWidget(label)
-        # self.setLayout(layout)
-        
-        # self.setStyleSheet(f"background-color: {self.color_name};")
-        
+               
 
         self.show()
 
     # Trigger a repaint to reflect the new size
     def set_window_size_and_position(self, init=False):
         user_size = self._fst.arg_manager.STATUS_INDICATOR_SIZE
-        padding = self.padding
+
+        #padding = self.padding
         # Window appearance        
         screen = get_current_screen()
         # Get the current global cursor position
         # screen_height = screen.geometry().height()
         size_multiplier = get_device_pixel_ratio(screen)
         # size_multiplier = get_device_pixel_ratio(screen)
-        user_size = int(user_size * size_multiplier)
-        padding = int(padding * size_multiplier)
+        self.user_size = int(user_size * size_multiplier)
+        padding = int(self.base_padding  * size_multiplier)
         dpadding = 2 * padding
         
         # Calculate the new size based on user size and padding
-        x_size = dpadding + user_size
-        y_size = dpadding + user_size
+        x_size = dpadding + self.user_size
+        y_size = dpadding + self.user_size
 
         if init :
             # On init, place at top-right corner of primary screen
@@ -521,8 +496,7 @@ class StatusOverlay(QWidget):
 
         self.setGeometry(top_left_x, top_left_y, x_size, y_size)
 
-        self.user_size = user_size
-        self.padding = padding
+        self.user_padding = padding
         self.x_size = x_size
         self.y_size = y_size
         self._current_screen = screen
@@ -535,7 +509,7 @@ class StatusOverlay(QWidget):
         painter.setRenderHint(QPainter.Antialiasing)
         painter.setBrush(self.color)
         painter.setPen(Qt.NoPen)
-        p = self.padding
+        p = self.user_padding
         s = self.user_size
         painter.drawEllipse(self.x_size - p - s, p, s, s)
         #print(f"Painting overlay at: {self.geometry()} with size ({self.x_size}, {self.y_size}) and padding {p}")      
@@ -563,7 +537,11 @@ class StatusOverlay(QWidget):
             new_left = new_center_x - self.x_size // 2
             new_top = new_center_y - self.y_size // 2
             self.move(new_left, new_top)
-
+            
+            # also drag the toast manager if it's visible
+            if hasattr(self.parent(), 'toast_manager'):
+                self.parent().toast_manager.update_position()
+                
             # Check if the screen changed during drag
             new_screen = get_current_screen()
             if new_screen != self._current_screen:
@@ -646,26 +624,116 @@ class StatusOverlay(QWidget):
         # Repaint to ensure color is updated
         self.update()
            
+           
+class ToastWidget(QFrame):
+    def __init__(self, text, duration=3., text_size=12, bg_color="rgba(40, 40, 40, 200)", text_color="white", timer=0, parent=None):
+        super().__init__(parent)
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.ToolTip | Qt.WindowStaysOnTopHint)
+        #self.setAttribute(Qt.WA_TranslucentBackground)
+        self.id = text
+        self.base_text = text
+        # Convert ms duration to seconds for the countdown
+        self.duration = duration * 1000
+        self.remaining_seconds = self.duration // 1000
+        
+        # This tells the widget: "Only be as wide as your text"
+        self.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Preferred)
+        
+        self.setStyleSheet(f"""
+            QFrame {{
+                background-color: {bg_color};
+                color: {text_color};
+                border-radius: 8px;
+                padding: 0px;
+                /* border: 1px solid rgba(255, 255, 255, 40); */
+            }}
+            QLabel {{ 
+                background: transparent; 
+                font-family: 'Consolas', 'Courier New', monospace; 
+                font-size: {text_size}px; 
+                font-weight: bold; 
+            }}
+        """)
 
-# --- Dummy usage stub for testing ---
-if __name__ == "__main__":
-    class DummyArgManager:
-        STATUS_INDICATOR_SIZE = 50
-        CROSSHAIR_DELTA_X = 0
-        CROSSHAIR_DELTA_Y = 0
-        CROSSHAIR_THICKNESS = 2
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0) # Left, Top, Right, Bottom margins
+        layout.setSpacing(0)
+        
+        layout.setSizeConstraint(QVBoxLayout.SetFixedSize) # Crucial for tight framing
+        if timer:
+            self.label = QLabel(self.get_display_text())
+        else:
+            self.label = QLabel(f" {text} ")
+        layout.addWidget(self.label)
+        
+        QTimer.singleShot(self.duration, self.deleteLater)
+        
+        if timer:
+            if self.remaining_seconds > 0:
+                self.tick_timer = QTimer(self)
+                self.tick_timer.timeout.connect(self.update_countdown)
+                self.tick_timer.start(1000) # Trigger every 1 second
+            self.adjustSize()
+        
+    
+    def get_display_text(self):
+        """Formats the text to include the timer."""
+        
+        return f" {self.base_text} | {self.remaining_seconds:3}s "
 
-    class DummyFST:
-        arg_manager = DummyArgManager()
-        def control_toggle_pause(self): print("Pause toggled")
-        def control_return_to_menu(self): print("Returned to menu")
-        def control_exit_program(self, from_where): print(f"Exit program: {from_where}")
-        def display_internal_repr_groups(self): print("Display internal state")
-        def open_config_file(self): print("Open config file")
-        def reload_from_file(self): print("Reload from file")
+    def update_countdown(self):
+        """Reduces the count and refreshes the label."""
+        self.remaining_seconds -= 1
+        if self.remaining_seconds >= 0:
+            self.label.setText(self.get_display_text())
+            # Note: We don't need to call adjustSize() here unless 
+            # the character count changes drastically (e.g. 10s to 9s)
 
-    def set_console_visibility(visible): print(f"Console visible?: {visible}")
+class ToastManager(QWidget):
+    def __init__(self, parent_overlay):
+        super().__init__()
+        self.parent_overlay = parent_overlay
+        self.setWindowFlags(Qt.FramelessWindowHint | Qt.WindowTransparentForInput | Qt.WindowStaysOnTopHint | Qt.Tool)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        
+        # FIX: Give it a large enough fixed width so it doesn't need to resize
+        # This prevents the 'jump' because the window itself never changes size.
+        self.setFixedWidth(500) 
+        
+        self.main_layout = QVBoxLayout(self)
+        self.main_layout.setContentsMargins(0, 0, 0, 0)
+        self.main_layout.setSpacing(3)
+        
+        # Align children to the top-right of our static 500px box
+        self.main_layout.setAlignment(Qt.AlignTop | Qt.AlignRight)
 
-    app = QApplication(sys.argv)
-    overlay = StatusOverlay(DummyFST(), set_console_visibility)
-    sys.exit(app.exec_())
+    def add_toast(self, text, duration, text_size, bg_color, text_color, timer):
+        toast = ToastWidget(text, duration, text_size, bg_color, text_color, timer)
+        self.main_layout.addWidget(toast, alignment=Qt.AlignRight)
+        
+        # Position the manager once (it stays anchored)
+        self.update_position()
+        self.show()
+
+    def update_position(self):
+        overlay_geo = self.parent_overlay.geometry()
+        parent_padding = self.parent_overlay.user_padding
+        
+        # Anchor the RIGHT edge of our 500px box to the RIGHT edge of the indicator
+        x = overlay_geo.right() - self.width() - parent_padding
+        # Anchor the TOP edge of our toasts just below the indicator
+        y = overlay_geo.bottom()
+        
+        self.move(x, y)
+
+    def check_empty(self):
+        if self.main_layout.count() == 0:
+            self.hide()
+    
+class ToastBridge(QObject):
+    # This acts as the thread-safe "translator"
+    signal_show_toast = Signal(str, int, int, str, str, int)  # text, duration, text_size, bg_color, text_color
+
+    def trigger_toast(self, text, duration, text_size, bg_color, text_color, timer):
+        # This method can be called safely by ANY thread
+        self.signal_show_toast.emit(text, duration, text_size, bg_color, text_color, timer)

--- a/fst_save_file_handler.py
+++ b/fst_save_file_handler.py
@@ -33,7 +33,7 @@ def make_backup(save_dir, backup_root_dir) -> str:
 
     # copytree requires that destination does not exist
     shutil.copytree(save_dir, backup_path)  # copies directory recursively[web:16][web:21]
-    return backup_path
+    return backup_path, backup_name
 
 
 def restore_backup(save_dir,backup_root_dir) -> str:
@@ -59,6 +59,6 @@ def restore_backup(save_dir,backup_root_dir) -> str:
         shutil.rmtree(save_dir)  # remove existing tree safely before restore[web:21][web:25]
 
     shutil.copytree(latest_path, save_dir)  # restore backup into save[web:16][web:21]
-    return latest_path
+    return latest_path, latest_name
 
 

--- a/fst_threads.py
+++ b/fst_threads.py
@@ -58,20 +58,24 @@ class Macro_Thread(Thread):
             if self._fst.arg_manager.DEBUG2:
                 print(f"D2: > playing macro: {self.alias_name} :: {self.key_group}")
             for key_event in self.key_group:
-                
+                if self.stop_event.is_set():
+                    #self.stop_event.clear()
+                    break
                 # check all constraints at start!
                 constraint_fulfilled, delay_times = self._fst.output_manager.check_constraint_fulfillment(key_event, get_also_delays=True)
 
                 if constraint_fulfilled:
                     if self.stop_event.is_set():
-                        self.stop_event.clear()
+                        #self.stop_event.clear()
                         break
                     else:
                         if key_event.is_toggle:
                             key_event = self._fst.output_manager.get_next_toggle_state_key_event(key_event)
                         # send key event and handles interruption of delay
                         self._fst.output_manager.execute_key_event(key_event, delay_times, with_delay=True, stop_event=self.stop_event)
-                       
+                        
+            if self.stop_event.is_set():
+                self.stop_event.clear()           
         except Exception as error:
             print(error)
             alias_thread_logging.append(error)
@@ -80,12 +84,14 @@ class Macro_Repeat_Thread(Thread):
     '''
     repeatatly execute a key event based on a timer
     '''
-    def __init__(self, alias_name, repeat_time, stop_event, fst_keyboard, time_increment=100):
+    def __init__(self, alias_name, repeat_time, stop_event, reset_event, with_overlay, fst_keyboard, time_increment=100):
         Thread.__init__(self)
         self.daemon = True
         self.alias_name = alias_name
         self.repeat_time = repeat_time
         self.stop_event = stop_event
+        self.reset_event  = reset_event
+        self.with_overlay = with_overlay
         self.time_increment = time_increment
         self.number_of_increments = self.repeat_time // time_increment
         self._fst = fst_keyboard
@@ -96,27 +102,28 @@ class Macro_Repeat_Thread(Thread):
         print(f"START REPEAT: {self.alias_name} with interval of {self.repeat_time} ms")
 
         while not self.stop_event.is_set():
-            if self.reset:
+
+            if self.reset_event.is_set():
                 self.macro_stop_event = Event()
-                self.reset = False
-                #print(f"D4: Repeat: {self.alias_name} reset")
-            else:
-                #print(f"D4: Repeat: {self.alias_name} execute")
-                self._fst.start_macro_playback(self.alias_name, self._fst.key_group_by_alias[self.alias_name], self.macro_stop_event)
+                self.reset_event.clear() # or can i clear an Event object again?
+            #print(f"D4: Repeat: {self.alias_name} reset")
+            #print(f"D4: Repeat: {self.alias_name} execute")
+            if self.with_overlay: 
+                self._fst.timer_callback(f"{self.alias_name}", self.repeat_time // 1000, 12, "rgba(40, 150, 40, 200)", "white")
+            self._fst.start_macro_playback(self.alias_name, self._fst.key_group_by_alias[self.alias_name], self.macro_stop_event)
             for index in range(self.number_of_increments):
-                if self.stop_event.is_set():
+                if self.stop_event.is_set() or self.reset_event.is_set():
                     self.macro_stop_event.set()
-                    break
-                elif self.reset:
+                    if self.with_overlay:
+                        self._fst.remove_callback(f"{self.alias_name}", immediately=1)
                     break
                 else:
                     sleep(self.time_increment / 1000)
+        if self.with_overlay:
+            self._fst.remove_callback(f"{self.alias_name}")
         # if stopped also stop the macro if it is still running
         print(f"STOP REPEAT: {self.alias_name} with interval of {self.repeat_time} ms")
-                
-    def reset_timer(self):
-        self.macro_stop_event.set()
-        self.reset = True
+             
         
             
 class Focus_Thread(Thread):

--- a/test_overlay.py
+++ b/test_overlay.py
@@ -10,9 +10,12 @@ from fst_overlay import GUI_Manager, ToastBridge
 class DummyFST:
     def __init__(self):
         self.arg_manager = type('obj', (object,), {
-            'STATUS_INDICATOR_SIZE': 10, 'CROSSHAIR_ENABLED': False, 
-            'STATUS_INDICATOR': True, 'TRAY_ICON': True, 
-            'ALWAYS_ACTIVE': False, 'MANUAL_PAUSED': False, 
+            'STATUS_INDICATOR_SIZE': 10, 
+            'CROSSHAIR_ENABLED': False, 
+            'STATUS_INDICATOR': True, 
+            'TRAY_ICON': True,        # Ensure this exists
+            'ALWAYS_ACTIVE': False, 
+            'MANUAL_PAUSED': False, 
             'WIN32_FILTER_PAUSED': False
         })
         self.focus_manager = type('obj', (object,), {'FOCUS_APP_NAME': ''})
@@ -24,11 +27,21 @@ class DummyFST:
             time.sleep(1)
             if self.toast_callback:
                 # Thread-safe call via the bridge
-                self.toast_callback("Thread: Task 1 Done", 3000, 12, "green", "white")
+                self.toast_callback("Thread: Task 1 Done ... 6s", 6, 14, "green", "white")
             time.sleep(2)
             if self.toast_callback:
-                self.toast_callback("Thread: Finalizing...", 2000, 10, "blue", "white")
-
+                self.toast_callback("Thread: Finalizing ... 15s", 15, 14, "blue", "white")
+            time.sleep(2)
+            self.timer_callback("Timer ... 15s", 15, 14, "orange", "white")
+            time.sleep(2)
+            self.timer_callback("Timer 20s", 20, 14, "orange", "white")
+            time.sleep(3)
+            self.remove_callback("Timer ... 15s")
+            time.sleep(4)
+            self.remove_all_callback()
+            time.sleep(2)
+            self.timer_callback("Timer ... 3s", 3, 14, "green", "white")
+            
         threading.Thread(target=task, daemon=True).start()
 
 # 2. Main Test Execution
@@ -36,19 +49,25 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
     
     # Initialize the real components
-    fst_logic = DummyFST()
-    gui_manager = GUI_Manager(fst_logic, app)
+    fst_keyboard = DummyFST()
+    gui_manager = GUI_Manager(fst_keyboard, app)
     
     # Setup the Bridge (The thread-safe glue)
     bridge = ToastBridge()
+        # Connect bridge signals to GUI manager slots
     bridge.signal_show_toast.connect(gui_manager.toast_manager.add_toast)
-    
-    # Inject the bridge into the dummy logic
-    fst_logic.toast_callback = bridge.trigger_toast
+    bridge.signal_show_timer.connect(gui_manager.toast_manager.add_timer)
+    bridge.signal_remove_toast.connect(gui_manager.toast_manager.remove_toast)
+    bridge.signal_remove_all_toasts.connect(gui_manager.toast_manager.remove_all_toasts)
+    # Inject the bridge methods into the keyboard logic for thread-safe calls
+    fst_keyboard.toast_callback = bridge.trigger_toast
+    fst_keyboard.timer_callback = bridge.trigger_timer
+    fst_keyboard.remove_callback = bridge.trigger_remove
+    fst_keyboard.remove_all_callback = bridge.trigger_remove_all
 
     # Start the simulated thread
-    fst_logic.run_background_tasks()
+    fst_keyboard.run_background_tasks()
 
     # Start the Qt Event Loop
     gui_manager.start()
-    time.sleep(12)  # Keep the main thread alive long enough to see the toasts  
+    time.sleep(30)  # Keep the main thread alive long enough to see the toasts  

--- a/test_overlay.py
+++ b/test_overlay.py
@@ -1,0 +1,54 @@
+import sys
+import threading
+import time
+from PySide6.QtWidgets import QApplication
+
+# Import your actual classes from your existing file
+from fst_overlay import GUI_Manager, ToastBridge
+
+# 1. Setup Mock Logic
+class DummyFST:
+    def __init__(self):
+        self.arg_manager = type('obj', (object,), {
+            'STATUS_INDICATOR_SIZE': 10, 'CROSSHAIR_ENABLED': False, 
+            'STATUS_INDICATOR': True, 'TRAY_ICON': True, 
+            'ALWAYS_ACTIVE': False, 'MANUAL_PAUSED': False, 
+            'WIN32_FILTER_PAUSED': False
+        })
+        self.focus_manager = type('obj', (object,), {'FOCUS_APP_NAME': ''})
+        self.toast_callback = None # The entry point for the bridge
+
+    def run_background_tasks(self):
+        """Simulates logic running in a nested thread."""
+        def task():
+            time.sleep(1)
+            if self.toast_callback:
+                # Thread-safe call via the bridge
+                self.toast_callback("Thread: Task 1 Done", 3000, 12, "green", "white")
+            time.sleep(2)
+            if self.toast_callback:
+                self.toast_callback("Thread: Finalizing...", 2000, 10, "blue", "white")
+
+        threading.Thread(target=task, daemon=True).start()
+
+# 2. Main Test Execution
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    
+    # Initialize the real components
+    fst_logic = DummyFST()
+    gui_manager = GUI_Manager(fst_logic, app)
+    
+    # Setup the Bridge (The thread-safe glue)
+    bridge = ToastBridge()
+    bridge.signal_show_toast.connect(gui_manager.toast_manager.add_toast)
+    
+    # Inject the bridge into the dummy logic
+    fst_logic.toast_callback = bridge.trigger_toast
+
+    # Start the simulated thread
+    fst_logic.run_background_tasks()
+
+    # Start the Qt Event Loop
+    gui_manager.start()
+    time.sleep(12)  # Keep the main thread alive long enough to see the toasts  


### PR DESCRIPTION
260428-1230
- fixed a bug in reset_repeat logic that lead to an entire repeat time with no action before starting again
- integrated in repeat function the toast message as timer
  - can optionally be disabled via with_overlay=0 in function
  - `start_repeat(alias_string, repeat_time, with_overlay=0)`
- added remove function for toasts, which is used by the repeat function if reset to prematurely restart a loop
  - works semi reliable on the repeat - has problems with to many repeat or with to fast restarts of a repeat and will generate multiple toasts
  - added function `remove_toast(text, immediately=0)` and `remove_all_toasts(immediately=0)` for deleting toasts manually
    - `immediately=1` will remove toast immediately
    - `immediately=0` default value will recolor toast red and display DEL at timer area, will be removed 1 second after recoloring
- added checks if status_indicator is even on before a toast/timer is posted

260427-2009
- Add several utility actions/functions to Output_Manager: 
  - `get_time()` # in ms since epoch
  - `mouse_get_pos()` # return tuple (x,y) coordinate of current mouse position and copies it into clipboard for easier pasting
  - `mouse_save_to_var(var)` # saves the tuple in a variable
  - `mouse_move_to_var(var)` # moves to the variable if it is a valid tuple
  - `copy_to_clipboard(var)` # copies selected variable to os clipboard
  - `paste()` # returns what is in the clipbaord for use in functions 
    - (not sure for what yet, but when you have a copy to clipboard then why not a paste also? :-P)
  - `save_into_file(text, time_stamp=get_time(), mode='w', file_path='output.txt')` # "{time_stamp}: {text}" saved into {file_path}')
  - `append_to_file(text, time_stamp=get_time(), file_path='output.txt')` #
  - `empty_file(file_path='output.txt')`
  - `print_all_variables()`
  - `clear_console()`
- Show toast messages when starting/stopping repeats and when making/restoring backups. 
- Update make_backup/restore_backup to return both path and name, and adjust fst_save_file_handler to return (path, name) tuples. A
- lso import time alongside datetime.

260427-1400
- added toast box for messages and timers
  - added toast message function that will be displayed under the status indicator overlay, that will vanish after set duration (ms)
    - show_message(*text*, *duration in s*, *text_size in px*, *background_color*, *text_color*)
      - `_|(show_message("test"))` # minimal message shown for 3 s
      - `_|(show_message("test", d=15, ts=15, bgc="green", tc="white"))`
      - bgc und tc also usable via `bgc="rgba(40, 40, 40, 200)"` and thus with alpha (transparency)
  - added timer toast message function that displays a countdown timer on the right side of the message text
    - `-up :: _|(show_timer("test", d=15, ts=15, bgc="green"))`
  - example with usage of alias use the same formatting for different timers
    ```
      # alias for timer that can be used for different timer when in combination with `get_var` and `set_var`
      <timer> _|(show_timer(get_var("text"), d=get_var("dur"), ts=15, bgc="rgba(40, 200, 40, 200)", tc="white"))
      -up :: _|(set_var("text","UPPPP 15"))|(set_var("dur",15)), <timer>
      -left :: _|(set_var("text","LEFFT 10"))|(set_var("dur",10)), <timer>
      -right :: <timer>
      -down :: _|(show_message("test", d=15, ts=15, bgc="green"))
    ```
- added function `get_var` and `set_var` for arbitrary variable assignments
  - if `get_var` is called before `set_var`, then the variable will be set to the string "None"
- added test_overlay.py for easier testing of the gui
